### PR TITLE
Use input_substr to retrieve text

### DIFF
--- a/src/passes/generate-php.js
+++ b/src/passes/generate-php.js
@@ -648,7 +648,7 @@ module.exports = function(ast, options) {
     parts.push([
         '',
         '    private function text() {',
-        '      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);',
+        '      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);',
         '    }',
         '',
         '    private function offset() {',

--- a/test/fixtures/char-class-no-mbstring.php
+++ b/test/fixtures/char-class-no-mbstring.php
@@ -103,7 +103,7 @@ class Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {

--- a/test/fixtures/char-class-no-mbstring.php52.php
+++ b/test/fixtures/char-class-no-mbstring.php52.php
@@ -102,7 +102,7 @@ class php52_compat_Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {

--- a/test/fixtures/char-class.php
+++ b/test/fixtures/char-class.php
@@ -101,7 +101,7 @@ class Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {

--- a/test/fixtures/char-class.php52.php
+++ b/test/fixtures/char-class.php52.php
@@ -100,7 +100,7 @@ class php52_compat_Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {

--- a/test/fixtures/chr-unicode.php
+++ b/test/fixtures/chr-unicode.php
@@ -101,7 +101,7 @@ class Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {

--- a/test/fixtures/chr-unicode.php52.php
+++ b/test/fixtures/chr-unicode.php52.php
@@ -100,7 +100,7 @@ class php52_compat_Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {

--- a/test/fixtures/wp-gutenberg-post-cached.pegjs
+++ b/test/fixtures/wp-gutenberg-post-cached.pegjs
@@ -1,33 +1,205 @@
 {
 
+/*
+ *
+ *    _____       _             _
+ *   / ____|     | |           | |
+ *  | |  __ _   _| |_ ___ _ __ | |__   ___ _ __ __ _
+ *  | | |_ | | | | __/ _ \ '_ \| '_ \ / _ \ '__/ _` |
+ *  | |__| | |_| | ||  __/ | | | |_) |  __/ | | (_| |
+ *   \_____|\__,_|\__\___|_| |_|_.__/ \___|_|  \__, |
+ *                                              __/ |
+ *                  GRAMMAR                    |___/
+ *
+ *
+ * Welcome to the grammar file for Gutenberg posts!
+ *
+ * Please don't be distracted by the functions at the top
+ * here - they're just helpers for the grammar below. We
+ * try to keep them as minimal and simple as possible,
+ * but the parser generator forces us to declare them at
+ * the beginning of the file.
+ *
+ * What follows is the official specification grammar for
+ * documents created or edited in Gutenberg. It starts at
+ * the top-level rule `Block_List`
+ *
+ * The grammar is defined by a series of _rules_ and ways
+ * to return matches on those rules. It's a _PEG_, a
+ * parsing expression grammar, which simply means that for
+ * each of our rules we have a set of sub-rules to match
+ * on and the generated parser will try them in order
+ * until it finds the first match.
+ *
+ * This grammar is a _specification_ (with as little actual
+ * code as we can get away with) which is used by the
+ * parser generator to generate the actual _parser_ which
+ * is used by Gutenberg. We generate two parsers: one in
+ * JavaScript for use the browser and one in PHP for
+ * WordPress itself. PEG parser generators are available
+ * in many languages, though different libraries may require
+ * some translation of this grammar into their syntax.
+ *
+ * For more information:
+ * @see https://pegjs.org
+ * @see https://en.wikipedia.org/wiki/Parsing_expression_grammar
+ *
+ */
+
 /** <?php
 // The `maybeJSON` function is not needed in PHP because its return semantics
 // are the same as `json_decode`
+
+// array arguments are backwards because of PHP
+if ( ! function_exists( 'peg_array_partition' ) ) {
+    function peg_array_partition( $array, $predicate ) {
+        $truthy = array();
+        $falsey = array();
+
+        foreach ( $array as $item ) {
+            call_user_func( $predicate, $item )
+                ? $truthy[] = $item
+                : $falsey[] = $item;
+        }
+
+        return array( $truthy, $falsey );
+    }
+}
+
+if ( ! function_exists( 'peg_join_blocks' ) ) {
+    function peg_join_blocks( $pre, $tokens, $post ) {
+        $blocks = array();
+
+        if ( ! empty( $pre ) ) {
+            $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+        }
+
+        foreach ( $tokens as $token ) {
+            list( $token, $html ) = $token;
+
+            $blocks[] = $token;
+
+            if ( ! empty( $html ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+            }
+        }
+
+        if ( ! empty( $post ) ) {
+            $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+        }
+
+        return $blocks;
+    }
+}
+
 ?> **/
 
+function freeform( s ) {
+    return s.length && {
+        attrs: {},
+        innerHTML: s
+    };
+}
+
+function joinBlocks( pre, tokens, post ) {
+    var blocks = [], i, l, html, item, token;
+
+    if ( pre.length ) {
+        blocks.push( freeform( pre ) );
+    }
+
+    for ( i = 0, l = tokens.length; i < l; i++ ) {
+        item = tokens[ i ];
+        token = item[ 0 ];
+        html = item[ 1 ];
+
+        blocks.push( token );
+        if ( html.length ) {
+            blocks.push( freeform( html ) );
+        }
+    }
+
+    if ( post.length ) {
+        blocks.push( freeform( post ) );
+    }
+
+    return blocks;
+}
+
 function maybeJSON( s ) {
-	try {
-		return JSON.parse( s );
-	} catch (e) {
-		return null;
-	}
+    try {
+        return JSON.parse( s );
+    } catch (e) {
+        return null;
+    }
+}
+
+function partition( predicate, list ) {
+    var i, l, item;
+    var truthy = [];
+    var falsey = [];
+
+    // nod to performance over a simpler reduce
+    // and clone model we could have taken here
+    for ( i = 0, l = list.length; i < l; i++ ) {
+        item = list[ i ];
+
+        predicate( item )
+            ? truthy.push( item )
+            : falsey.push( item )
+    };
+
+    return [ truthy, falsey ];
 }
 
 }
 
-Document
-  = WP_Block_List
+//////////////////////////////////////////////////////
+//
+//   Here starts the grammar proper!
+//
+//////////////////////////////////////////////////////
 
-WP_Block_List
-  = WP_Block*
+Block_List
+  = pre:$(!Token .)*
+    ts:(t:Token html:$((!Token .)*) { /** <?php return array( $t, $html ); ?> **/ return [ t, html ] })*
+    post:$(.*)
+  { /** <?php return peg_join_blocks( $pre, $ts, $post ); ?> **/
+    return joinBlocks( pre, ts, post );
+  }
 
-WP_Block
-  = WP_Block_Void
-  / WP_Block_Balanced
-  / WP_Block_Html
+Token
+  = Tag_More
+  / Block_Void
+  / Block_Balanced
 
-WP_Block_Void
-  = "<!--" WS+ "wp:" blockName:WP_Block_Name WS+ attrs:(a:WP_Block_Attributes WS+ {
+Tag_More
+  = "<!--" WS* "more" customText:(WS+ text:$((!(WS* "-->") .)+) { /** <?php return $text; ?> **/ return text })? WS* "-->" noTeaser:(WS* "<!--noteaser-->")?
+  { /** <?php
+    $attrs = array( 'noTeaser' => (bool) $noTeaser );
+    if ( ! empty( $customText ) ) {
+      $attrs['customText'] = $customText;
+    }
+    return array(
+       'blockName' => 'core/more',
+       'attrs' => $attrs,
+       'innerHTML' => '',
+       'outerHTML' => $this->text(),
+    );
+    ?> **/
+    return {
+      blockName: 'core/more',
+      attrs: {
+        customText: customText || undefined,
+        noTeaser: !! noTeaser
+      },
+      innerHTML: '',
+      outerHTML: text()
+    }
+  }
+
+Block_Void
+  = "<!--" WS+ "wp:" blockName:Block_Name WS+ attrs:(a:Block_Attributes WS+ {
     /** <?php return $a; ?> **/
     return a;
   })? "/-->"
@@ -36,62 +208,51 @@ WP_Block_Void
     return array(
       'blockName'  => $blockName,
       'attrs'      => $attrs,
-      'rawContent' => '',
+      'innerBlocks' => array(),
+      'innerHTML' => '',
+      'outerHTML' => $this->text(),
     );
     ?> **/
 
     return {
       blockName: blockName,
       attrs: attrs,
-      rawContent: ''
+      innerBlocks: [],
+      innerHTML: '',
+      outerHTML: text()
     };
   }
 
-WP_Block_Balanced
-  = s:WP_Block_Start ts:(!WP_Block_End c:Any {
-    /** <?php return $c; ?> **/
-    return c;
-  })* e:WP_Block_End & {
-    /** <?php return $s['blockName'] === $e['blockName']; ?> **/
-    return s.blockName === e.blockName;
-  }
+Block_Balanced
+  = s:Block_Start children:(Token / $(!Block_End .))* e:Block_End
   {
     /** <?php
+    list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+
     return array(
       'blockName'  => $s['blockName'],
       'attrs'      => $s['attrs'],
-      'rawContent' => implode( '', $ts ),
+      'innerBlocks'  => $innerBlocks,
+      'innerHTML'  => implode( '', $innerHTML ),
+      'outerHTML' => $this->text(),
     );
     ?> **/
+
+    var innerContent = partition( function( a ) { return 'string' === typeof a }, children );
+    var innerHTML = innerContent[ 0 ];
+    var innerBlocks = innerContent[ 1 ];
 
     return {
       blockName: s.blockName,
       attrs: s.attrs,
-      rawContent: ts.join( '' )
+      innerBlocks: innerBlocks,
+      innerHTML: innerHTML.join( '' ),
+      outerHTML: text()
     };
   }
 
-WP_Block_Html
-  = ts:(!WP_Block_Balanced !WP_Block_Void c:Any {
-    /** <?php return $c; ?> **/
-    return c;
-  })+
-  {
-    /** <?php
-    return array(
-      'attrs'      => array(),
-      'rawContent' => implode( '', $ts ),
-    );
-    ?> **/
-
-    return {
-      attrs: {},
-      rawContent: ts.join( '' )
-    }
-  }
-
-WP_Block_Start
-  = "<!--" WS+ "wp:" blockName:WP_Block_Name WS+ attrs:(a:WP_Block_Attributes WS+ {
+Block_Start
+  = "<!--" WS+ "wp:" blockName:Block_Name WS+ attrs:(a:Block_Attributes WS+ {
     /** <?php return $a; ?> **/
     return a;
   })? "-->"
@@ -109,8 +270,8 @@ WP_Block_Start
     };
   }
 
-WP_Block_End
-  = "<!--" WS+ "/wp:" blockName:WP_Block_Name WS+ "-->"
+Block_End
+  = "<!--" WS+ "/wp:" blockName:Block_Name WS+ "-->"
   {
     /** <?php
     return array(
@@ -123,29 +284,29 @@ WP_Block_End
     };
   }
 
-WP_Block_Name
-  = $(ASCII_Letter (ASCII_AlphaNumeric / "/" ASCII_AlphaNumeric)*)
+Block_Name
+  = Namespaced_Block_Name
+  / Core_Block_Name
 
-WP_Block_Attributes
+Namespaced_Block_Name
+  = $( Block_Name_Part "/" Block_Name_Part )
+
+Core_Block_Name
+  = type:$( Block_Name_Part )
+  {
+    /** <?php return "core/$type"; ?> **/
+    return 'core/' + type;
+  }
+
+Block_Name_Part
+  = $( [a-z][a-z0-9_-]* )
+
+Block_Attributes
   = attrs:$("{" (!("}" WS+ """/"? "-->") .)* "}")
   {
     /** <?php return json_decode( $attrs, true ); ?> **/
     return maybeJSON( attrs );
   }
-
-ASCII_AlphaNumeric
-  = ASCII_Letter
-  / ASCII_Digit
-  / Special_Chars
-
-ASCII_Letter
-  = [a-zA-Z]
-
-ASCII_Digit
-  = [0-9]
-
-Special_Chars
-  = [\-\_]
 
 WS
   = [ \t\r\n]

--- a/test/fixtures/wp-gutenberg-post-cached.php
+++ b/test/fixtures/wp-gutenberg-post-cached.php
@@ -102,7 +102,7 @@ class Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {
@@ -258,29 +258,43 @@ class Parser {
     private $peg_c27;
     private $peg_c28;
     private $peg_c29;
+    private $peg_c30;
+    private $peg_c31;
 
-    private function peg_f0($blockName, $a) { return $a; }
-    private function peg_f1($blockName, $attrs) {
+    private function peg_f0($pre, $t, $html) { return array( $t, $html ); }
+    private function peg_f1($pre, $ts, $post) { return peg_join_blocks( $pre, $ts, $post ); }
+    private function peg_f2($text) { return $text; }
+    private function peg_f3($customText, $noTeaser) {
+        $attrs = array( 'noTeaser' => (bool) $noTeaser );
+        if ( ! empty( $customText ) ) {
+          $attrs['customText'] = $customText;
+        }
+        return array(
+           'blockName' => 'core/more',
+           'attrs' => $attrs,
+           'innerHTML' => '',
+           'outerHTML' => $this->text(),
+        );
+        }
+    private function peg_f4($blockName, $a) { return $a; }
+    private function peg_f5($blockName, $attrs) {
         return array(
           'blockName'  => $blockName,
           'attrs'      => $attrs,
-          'rawContent' => '',
+          'innerBlocks' => array(),
+          'innerHTML' => '',
+          'outerHTML' => $this->text(),
         );
         }
-    private function peg_f2($s, $c) { return $c; }
-    private function peg_f3($s, $ts, $e) { return $s['blockName'] === $e['blockName']; }
-    private function peg_f4($s, $ts, $e) {
+    private function peg_f6($s, $children, $e) {
+        list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+
         return array(
           'blockName'  => $s['blockName'],
           'attrs'      => $s['attrs'],
-          'rawContent' => implode( '', $ts ),
-        );
-        }
-    private function peg_f5($c) { return $c; }
-    private function peg_f6($ts) {
-        return array(
-          'attrs'      => array(),
-          'rawContent' => implode( '', $ts ),
+          'innerBlocks'  => $innerBlocks,
+          'innerHTML'  => implode( '', $innerHTML ),
+          'outerHTML' => $this->text(),
         );
         }
     private function peg_f7($blockName, $attrs) {
@@ -294,73 +308,12 @@ class Parser {
           'blockName' => $blockName,
         );
         }
-    private function peg_f9($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f9($type) { return "core/$type"; }
+    private function peg_f10($attrs) { return json_decode( $attrs, true ); }
 
-    private function peg_parseDocument() {
+    private function peg_parseBlock_List() {
 
-      $key    = $this->peg_currPos * 19 + 0;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      $s0 = $this->peg_parseWP_Block_List();
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block_List() {
-
-      $key    = $this->peg_currPos * 19 + 1;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      $s0 = array();
-      $s1 = $this->peg_parseWP_Block();
-      while ($s1 !== $this->peg_FAILED) {
-        $s0[] = $s1;
-        $s1 = $this->peg_parseWP_Block();
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block() {
-
-      $key    = $this->peg_currPos * 19 + 2;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      $s0 = $this->peg_parseWP_Block_Void();
-      if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseWP_Block_Balanced();
-        if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseWP_Block_Html();
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block_Void() {
-
-      $key    = $this->peg_currPos * 19 + 3;
+      $key    = $this->peg_currPos * 17 + 0;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -369,91 +322,586 @@ class Parser {
       }
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      $s1 = $this->peg_currPos;
+      $s2 = array();
+      $s3 = $this->peg_currPos;
+      $s4 = $this->peg_currPos;
+      $this->peg_silentFails++;
+      $s5 = $this->peg_parseToken();
+      $this->peg_silentFails--;
+      if ($s5 === $this->peg_FAILED) {
+        $s4 = null;
+      } else {
+        $this->peg_currPos = $s4;
+        $s4 = $this->peg_FAILED;
+      }
+      if ($s4 !== $this->peg_FAILED) {
+        if ($this->input_length > $this->peg_currPos) {
+          $s5 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s5 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c0);
+          }
+        }
+        if ($s5 !== $this->peg_FAILED) {
+          $s4 = array($s4, $s5);
+          $s3 = $s4;
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s3;
+        $s3 = $this->peg_FAILED;
+      }
+      while ($s3 !== $this->peg_FAILED) {
+        $s2[] = $s3;
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_currPos;
+        $this->peg_silentFails++;
+        $s5 = $this->peg_parseToken();
+        $this->peg_silentFails--;
+        if ($s5 === $this->peg_FAILED) {
+          $s4 = null;
+        } else {
+          $this->peg_currPos = $s4;
+          $s4 = $this->peg_FAILED;
+        }
+        if ($s4 !== $this->peg_FAILED) {
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $s4 = array($s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      }
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_parseToken();
+        if ($s4 !== $this->peg_FAILED) {
+          $s5 = $this->peg_currPos;
+          $s6 = array();
+          $s7 = $this->peg_currPos;
+          $s8 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          $s9 = $this->peg_parseToken();
+          $this->peg_silentFails--;
+          if ($s9 === $this->peg_FAILED) {
+            $s8 = null;
+          } else {
+            $this->peg_currPos = $s8;
+            $s8 = $this->peg_FAILED;
+          }
+          if ($s8 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s9 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s9 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s9 !== $this->peg_FAILED) {
+              $s8 = array($s8, $s9);
+              $s7 = $s8;
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s7;
+            $s7 = $this->peg_FAILED;
+          }
+          while ($s7 !== $this->peg_FAILED) {
+            $s6[] = $s7;
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          }
+          if ($s6 !== $this->peg_FAILED) {
+            $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+          } else {
+            $s5 = $s6;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s3;
+            $s4 = $this->peg_f0($s1, $s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_currPos;
+          $s4 = $this->peg_parseToken();
+          if ($s4 !== $this->peg_FAILED) {
+            $s5 = $this->peg_currPos;
+            $s6 = array();
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+            while ($s7 !== $this->peg_FAILED) {
+              $s6[] = $s7;
+              $s7 = $this->peg_currPos;
+              $s8 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s9 = $this->peg_parseToken();
+              $this->peg_silentFails--;
+              if ($s9 === $this->peg_FAILED) {
+                $s8 = null;
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s9 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s9 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s9 !== $this->peg_FAILED) {
+                  $s8 = array($s8, $s9);
+                  $s7 = $s8;
+                } else {
+                  $this->peg_currPos = $s7;
+                  $s7 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+            } else {
+              $s5 = $s6;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s3;
+              $s4 = $this->peg_f0($s1, $s4, $s5);
+              $s3 = $s4;
+            } else {
+              $this->peg_currPos = $s3;
+              $s3 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_currPos;
+          $s4 = array();
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          while ($s5 !== $this->peg_FAILED) {
+            $s4[] = $s5;
+            if ($this->input_length > $this->peg_currPos) {
+              $s5 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s5 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f1($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
+      }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
+    private function peg_parseToken() {
+
+      $key    = $this->peg_currPos * 17 + 1;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      $s0 = $this->peg_parseTag_More();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_parseBlock_Void();
+        if ($s0 === $this->peg_FAILED) {
+          $s0 = $this->peg_parseBlock_Balanced();
+        }
+      }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
+    private function peg_parseTag_More() {
+
+      $key    = $this->peg_currPos * 17 + 2;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      $s0 = $this->peg_currPos;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
         $s3 = $this->peg_parseWS();
-        if ($s3 !== $this->peg_FAILED) {
-          while ($s3 !== $this->peg_FAILED) {
-            $s2[] = $s3;
-            $s3 = $this->peg_parseWS();
-          }
-        } else {
-          $s2 = $this->peg_FAILED;
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseWS();
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
-            $this->peg_currPos += 3;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c3) {
+            $s3 = $this->peg_c3;
+            $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c4);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_currPos;
+            $s5 = array();
+            $s6 = $this->peg_parseWS();
+            if ($s6 !== $this->peg_FAILED) {
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
+              }
+            } else {
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $s6 = $this->peg_currPos;
+              $s7 = array();
+              $s8 = $this->peg_currPos;
+              $s9 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s10 = $this->peg_currPos;
+              $s11 = array();
+              $s12 = $this->peg_parseWS();
+              while ($s12 !== $this->peg_FAILED) {
+                $s11[] = $s12;
+                $s12 = $this->peg_parseWS();
+              }
+              if ($s11 !== $this->peg_FAILED) {
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
+                  $this->peg_currPos += 3;
+                } else {
+                  $s12 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
+                }
+                if ($s12 !== $this->peg_FAILED) {
+                  $s11 = array($s11, $s12);
+                  $s10 = $s11;
+                } else {
+                  $this->peg_currPos = $s10;
+                  $s10 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s10;
+                $s10 = $this->peg_FAILED;
+              }
+              $this->peg_silentFails--;
+              if ($s10 === $this->peg_FAILED) {
+                $s9 = null;
+              } else {
+                $this->peg_currPos = $s9;
+                $s9 = $this->peg_FAILED;
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s10 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s10 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s10 !== $this->peg_FAILED) {
+                  $s9 = array($s9, $s10);
+                  $s8 = $s9;
+                } else {
+                  $this->peg_currPos = $s8;
+                  $s8 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                while ($s8 !== $this->peg_FAILED) {
+                  $s7[] = $s8;
+                  $s8 = $this->peg_currPos;
+                  $s9 = $this->peg_currPos;
+                  $this->peg_silentFails++;
+                  $s10 = $this->peg_currPos;
+                  $s11 = array();
+                  $s12 = $this->peg_parseWS();
+                  while ($s12 !== $this->peg_FAILED) {
+                    $s11[] = $s12;
+                    $s12 = $this->peg_parseWS();
+                  }
+                  if ($s11 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                      $s12 = $this->peg_c5;
+                      $this->peg_currPos += 3;
+                    } else {
+                      $s12 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c6);
+                      }
+                    }
+                    if ($s12 !== $this->peg_FAILED) {
+                      $s11 = array($s11, $s12);
+                      $s10 = $s11;
+                    } else {
+                      $this->peg_currPos = $s10;
+                      $s10 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s10;
+                    $s10 = $this->peg_FAILED;
+                  }
+                  $this->peg_silentFails--;
+                  if ($s10 === $this->peg_FAILED) {
+                    $s9 = null;
+                  } else {
+                    $this->peg_currPos = $s9;
+                    $s9 = $this->peg_FAILED;
+                  }
+                  if ($s9 !== $this->peg_FAILED) {
+                    if ($this->input_length > $this->peg_currPos) {
+                      $s10 = $this->input_substr($this->peg_currPos, 1);
+                      $this->peg_currPos++;
+                    } else {
+                      $s10 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c0);
+                      }
+                    }
+                    if ($s10 !== $this->peg_FAILED) {
+                      $s9 = array($s9, $s10);
+                      $s8 = $s9;
+                    } else {
+                      $this->peg_currPos = $s8;
+                      $s8 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s8;
+                    $s8 = $this->peg_FAILED;
+                  }
+                }
+              } else {
+                $s7 = $this->peg_FAILED;
+              }
+              if ($s7 !== $this->peg_FAILED) {
+                $s6 = $this->input_substr($s6, $this->peg_currPos - $s6);
+              } else {
+                $s6 = $s7;
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $this->peg_reportedPos = $s4;
+                $s5 = $this->peg_f2($s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+            if ($s4 === $this->peg_FAILED) {
+              $s4 = null;
+            }
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
-              if ($s6 !== $this->peg_FAILED) {
-                while ($s6 !== $this->peg_FAILED) {
-                  $s5[] = $s6;
-                  $s6 = $this->peg_parseWS();
-                }
-              } else {
-                $s5 = $this->peg_FAILED;
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
               }
               if ($s5 !== $this->peg_FAILED) {
-                $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
-                if ($s7 !== $this->peg_FAILED) {
-                  $s8 = array();
-                  $s9 = $this->peg_parseWS();
-                  if ($s9 !== $this->peg_FAILED) {
-                    while ($s9 !== $this->peg_FAILED) {
-                      $s8[] = $s9;
-                      $s9 = $this->peg_parseWS();
-                    }
-                  } else {
-                    $s8 = $this->peg_FAILED;
-                  }
-                  if ($s8 !== $this->peg_FAILED) {
-                    $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
-                    $s6 = $s7;
-                  } else {
-                    $this->peg_currPos = $s6;
-                    $s6 = $this->peg_FAILED;
-                  }
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
+                  $this->peg_currPos += 3;
                 } else {
-                  $this->peg_currPos = $s6;
                   $s6 = $this->peg_FAILED;
-                }
-                if ($s6 === $this->peg_FAILED) {
-                  $s6 = null;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c4) {
-                    $s7 = $this->peg_c4;
-                    $this->peg_currPos += 4;
-                  } else {
-                    $s7 = $this->peg_FAILED;
-                    if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c5);
+                  $s7 = $this->peg_currPos;
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  while ($s9 !== $this->peg_FAILED) {
+                    $s8[] = $s9;
+                    $s9 = $this->peg_parseWS();
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 15) === $this->peg_c7) {
+                      $s9 = $this->peg_c7;
+                      $this->peg_currPos += 15;
+                    } else {
+                      $s9 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c8);
+                      }
                     }
+                    if ($s9 !== $this->peg_FAILED) {
+                      $s8 = array($s8, $s9);
+                      $s7 = $s8;
+                    } else {
+                      $this->peg_currPos = $s7;
+                      $s7 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s7;
+                    $s7 = $this->peg_FAILED;
+                  }
+                  if ($s7 === $this->peg_FAILED) {
+                    $s7 = null;
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f1($s4, $s6);
+                    $s1 = $this->peg_f3($s4, $s7);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -489,9 +937,9 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Balanced() {
+    private function peg_parseBlock_Void() {
 
-      $key    = $this->peg_currPos * 19 + 4;
+      $key    = $this->peg_currPos * 17 + 3;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -500,76 +948,104 @@ class Parser {
       }
 
       $s0 = $this->peg_currPos;
-      $s1 = $this->peg_parseWP_Block_Start();
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
+        $this->peg_currPos += 4;
+      } else {
+        $s1 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c2);
+        }
+      }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
-        $s3 = $this->peg_currPos;
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_End();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s3;
-            $s4 = $this->peg_f2($s1, $s5);
-            $s3 = $s4;
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+        $s3 = $this->peg_parseWS();
+        if ($s3 !== $this->peg_FAILED) {
+          while ($s3 !== $this->peg_FAILED) {
+            $s2[] = $s3;
+            $s3 = $this->peg_parseWS();
           }
         } else {
-          $this->peg_currPos = $s3;
-          $s3 = $this->peg_FAILED;
-        }
-        while ($s3 !== $this->peg_FAILED) {
-          $s2[] = $s3;
-          $s3 = $this->peg_currPos;
-          $s4 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s5 = $this->peg_parseWP_Block_End();
-          $this->peg_silentFails--;
-          if ($s5 === $this->peg_FAILED) {
-            $s4 = null;
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
-          }
-          if ($s4 !== $this->peg_FAILED) {
-            $s5 = $this->peg_parseAny();
-            if ($s5 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s3;
-              $s4 = $this->peg_f2($s1, $s5);
-              $s3 = $s4;
-            } else {
-              $this->peg_currPos = $s3;
-              $s3 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
-          }
+          $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          $s3 = $this->peg_parseWP_Block_End();
-          if ($s3 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $this->peg_currPos;
-            $s4 = $this->peg_f3($s1, $s2, $s3);
-            if ($s4) {
-              $s4 = null;
-            } else {
-              $s4 = $this->peg_FAILED;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
+            $this->peg_currPos += 3;
+          } else {
+            $s3 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c10);
             }
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s0;
-              $s1 = $this->peg_f4($s1, $s2, $s3);
-              $s0 = $s1;
+              $s5 = array();
+              $s6 = $this->peg_parseWS();
+              if ($s6 !== $this->peg_FAILED) {
+                while ($s6 !== $this->peg_FAILED) {
+                  $s5[] = $s6;
+                  $s6 = $this->peg_parseWS();
+                }
+              } else {
+                $s5 = $this->peg_FAILED;
+              }
+              if ($s5 !== $this->peg_FAILED) {
+                $s6 = $this->peg_currPos;
+                $s7 = $this->peg_parseBlock_Attributes();
+                if ($s7 !== $this->peg_FAILED) {
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  if ($s9 !== $this->peg_FAILED) {
+                    while ($s9 !== $this->peg_FAILED) {
+                      $s8[] = $s9;
+                      $s9 = $this->peg_parseWS();
+                    }
+                  } else {
+                    $s8 = $this->peg_FAILED;
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s6;
+                    $s7 = $this->peg_f4($s4, $s7);
+                    $s6 = $s7;
+                  } else {
+                    $this->peg_currPos = $s6;
+                    $s6 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s6;
+                  $s6 = $this->peg_FAILED;
+                }
+                if ($s6 === $this->peg_FAILED) {
+                  $s6 = null;
+                }
+                if ($s6 !== $this->peg_FAILED) {
+                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c11) {
+                    $s7 = $this->peg_c11;
+                    $this->peg_currPos += 4;
+                  } else {
+                    $s7 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c12);
+                    }
+                  }
+                  if ($s7 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s0;
+                    $s1 = $this->peg_f5($s4, $s6);
+                    $s0 = $s1;
+                  } else {
+                    $this->peg_currPos = $s0;
+                    $s0 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s0;
+                  $s0 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s0;
+                $s0 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s0;
               $s0 = $this->peg_FAILED;
@@ -592,9 +1068,9 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Html() {
+    private function peg_parseBlock_Balanced() {
 
-      $key    = $this->peg_currPos * 19 + 5;
+      $key    = $this->peg_currPos * 17 + 4;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -603,108 +1079,121 @@ class Parser {
       }
 
       $s0 = $this->peg_currPos;
-      $s1 = array();
-      $s2 = $this->peg_currPos;
-      $s3 = $this->peg_currPos;
-      $this->peg_silentFails++;
-      $s4 = $this->peg_parseWP_Block_Balanced();
-      $this->peg_silentFails--;
-      if ($s4 === $this->peg_FAILED) {
-        $s3 = null;
-      } else {
-        $this->peg_currPos = $s3;
-        $s3 = $this->peg_FAILED;
-      }
-      if ($s3 !== $this->peg_FAILED) {
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_Void();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s2;
-            $s3 = $this->peg_f5($s5);
-            $s2 = $s3;
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
-          }
-        } else {
-          $this->peg_currPos = $s2;
-          $s2 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s2;
-        $s2 = $this->peg_FAILED;
-      }
-      if ($s2 !== $this->peg_FAILED) {
-        while ($s2 !== $this->peg_FAILED) {
-          $s1[] = $s2;
-          $s2 = $this->peg_currPos;
+      $s1 = $this->peg_parseBlock_Start();
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_parseToken();
+        if ($s3 === $this->peg_FAILED) {
           $s3 = $this->peg_currPos;
+          $s4 = $this->peg_currPos;
+          $s5 = $this->peg_currPos;
           $this->peg_silentFails++;
-          $s4 = $this->peg_parseWP_Block_Balanced();
+          $s6 = $this->peg_parseBlock_End();
           $this->peg_silentFails--;
-          if ($s4 === $this->peg_FAILED) {
-            $s3 = null;
+          if ($s6 === $this->peg_FAILED) {
+            $s5 = null;
           } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
           }
-          if ($s3 !== $this->peg_FAILED) {
+          if ($s5 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s6 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s6 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = array($s5, $s6);
+              $s4 = $s5;
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseToken();
+          if ($s3 === $this->peg_FAILED) {
+            $s3 = $this->peg_currPos;
             $s4 = $this->peg_currPos;
+            $s5 = $this->peg_currPos;
             $this->peg_silentFails++;
-            $s5 = $this->peg_parseWP_Block_Void();
+            $s6 = $this->peg_parseBlock_End();
             $this->peg_silentFails--;
-            if ($s5 === $this->peg_FAILED) {
-              $s4 = null;
+            if ($s6 === $this->peg_FAILED) {
+              $s5 = null;
+            } else {
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s6 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s6 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $s5 = array($s5, $s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s4;
               $s4 = $this->peg_FAILED;
             }
             if ($s4 !== $this->peg_FAILED) {
-              $s5 = $this->peg_parseAny();
-              if ($s5 !== $this->peg_FAILED) {
-                $this->peg_reportedPos = $s2;
-                $s3 = $this->peg_f5($s5);
-                $s2 = $s3;
-              } else {
-                $this->peg_currPos = $s2;
-                $s2 = $this->peg_FAILED;
-              }
+              $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
             } else {
-              $this->peg_currPos = $s2;
-              $s2 = $this->peg_FAILED;
+              $s3 = $s4;
             }
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
           }
         }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_parseBlock_End();
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f6($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
       } else {
-        $s1 = $this->peg_FAILED;
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
-      if ($s1 !== $this->peg_FAILED) {
-        $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f6($s1);
-      }
-      $s0 = $s1;
 
       $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
 
       return $s0;
     }
 
-    private function peg_parseWP_Block_Start() {
+    private function peg_parseBlock_Start() {
 
-      $key    = $this->peg_currPos * 19 + 6;
+      $key    = $this->peg_currPos * 17 + 5;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -713,13 +1202,13 @@ class Parser {
       }
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -734,17 +1223,17 @@ class Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
             $this->peg_currPos += 3;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c10);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -758,7 +1247,7 @@ class Parser {
               }
               if ($s5 !== $this->peg_FAILED) {
                 $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
+                $s7 = $this->peg_parseBlock_Attributes();
                 if ($s7 !== $this->peg_FAILED) {
                   $s8 = array();
                   $s9 = $this->peg_parseWS();
@@ -772,7 +1261,7 @@ class Parser {
                   }
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
+                    $s7 = $this->peg_f4($s4, $s7);
                     $s6 = $s7;
                   } else {
                     $this->peg_currPos = $s6;
@@ -786,13 +1275,13 @@ class Parser {
                   $s6 = null;
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s7 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s7 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s7 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s7 !== $this->peg_FAILED) {
@@ -833,9 +1322,9 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_End() {
+    private function peg_parseBlock_End() {
 
-      $key    = $this->peg_currPos * 19 + 7;
+      $key    = $this->peg_currPos * 17 + 6;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -844,13 +1333,13 @@ class Parser {
       }
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -865,17 +1354,17 @@ class Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c8) {
-            $s3 = $this->peg_c8;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c13) {
+            $s3 = $this->peg_c13;
             $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c9);
+                $this->peg_fail($this->peg_c14);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -888,13 +1377,13 @@ class Parser {
                 $s5 = $this->peg_FAILED;
               }
               if ($s5 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s6 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s6 !== $this->peg_FAILED) {
@@ -931,9 +1420,29 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Name() {
+    private function peg_parseBlock_Name() {
 
-      $key    = $this->peg_currPos * 19 + 8;
+      $key    = $this->peg_currPos * 17 + 7;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      $s0 = $this->peg_parseNamespaced_Block_Name();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_parseCore_Block_Name();
+      }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
+    private function peg_parseNamespaced_Block_Name() {
+
+      $key    = $this->peg_currPos * 17 + 8;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -943,61 +1452,115 @@ class Parser {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
-      $s2 = $this->peg_parseASCII_Letter();
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+          $s3 = $this->peg_c15;
+          $this->peg_currPos++;
+        } else {
+          $s3 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c16);
+          }
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s4 = $this->peg_parseBlock_Name_Part();
+          if ($s4 !== $this->peg_FAILED) {
+            $s2 = array($s2, $s3, $s4);
+            $s1 = $s2;
+          } else {
+            $this->peg_currPos = $s1;
+            $s1 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s1;
+          $s1 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s1;
+        $s1 = $this->peg_FAILED;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+      } else {
+        $s0 = $s1;
+      }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
+    private function peg_parseCore_Block_Name() {
+
+      $key    = $this->peg_currPos * 17 + 9;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $s0;
+        $s1 = $this->peg_f9($s1);
+      }
+      $s0 = $s1;
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
+    private function peg_parseBlock_Name_Part() {
+
+      $key    = $this->peg_currPos * 17 + 10;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      if (peg_regex_test($this->peg_c17, $this->input_substr($this->peg_currPos, 1))) {
+        $s2 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s2 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c18);
+        }
+      }
       if ($s2 !== $this->peg_FAILED) {
         $s3 = array();
-        $s4 = $this->peg_parseASCII_AlphaNumeric();
-        if ($s4 === $this->peg_FAILED) {
-          $s4 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-            $s5 = $this->peg_c10;
-            $this->peg_currPos++;
-          } else {
-            $s5 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c11);
-            }
-          }
-          if ($s5 !== $this->peg_FAILED) {
-            $s6 = $this->peg_parseASCII_AlphaNumeric();
-            if ($s6 !== $this->peg_FAILED) {
-              $s5 = array($s5, $s6);
-              $s4 = $s5;
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
+        if (peg_regex_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+          $s4 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s4 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c20);
           }
         }
         while ($s4 !== $this->peg_FAILED) {
           $s3[] = $s4;
-          $s4 = $this->peg_parseASCII_AlphaNumeric();
-          if ($s4 === $this->peg_FAILED) {
-            $s4 = $this->peg_currPos;
-            if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-              $s5 = $this->peg_c10;
-              $this->peg_currPos++;
-            } else {
-              $s5 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c11);
-              }
-            }
-            if ($s5 !== $this->peg_FAILED) {
-              $s6 = $this->peg_parseASCII_AlphaNumeric();
-              if ($s6 !== $this->peg_FAILED) {
-                $s5 = array($s5, $s6);
-                $s4 = $s5;
-              } else {
-                $this->peg_currPos = $s4;
-                $s4 = $this->peg_FAILED;
-              }
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
+          if (peg_regex_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+            $s4 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s4 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c20);
             }
           }
         }
@@ -1023,9 +1586,9 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Attributes() {
+    private function peg_parseBlock_Attributes() {
 
-      $key    = $this->peg_currPos * 19 + 9;
+      $key    = $this->peg_currPos * 17 + 11;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -1036,13 +1599,13 @@ class Parser {
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c12) {
-        $s3 = $this->peg_c12;
+      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c21) {
+        $s3 = $this->peg_c21;
         $this->peg_currPos++;
       } else {
         $s3 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c13);
+            $this->peg_fail($this->peg_c22);
         }
       }
       if ($s3 !== $this->peg_FAILED) {
@@ -1051,13 +1614,13 @@ class Parser {
         $s6 = $this->peg_currPos;
         $this->peg_silentFails++;
         $s7 = $this->peg_currPos;
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-          $s8 = $this->peg_c14;
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+          $s8 = $this->peg_c23;
           $this->peg_currPos++;
         } else {
           $s8 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c15);
+              $this->peg_fail($this->peg_c24);
           }
         }
         if ($s8 !== $this->peg_FAILED) {
@@ -1072,28 +1635,28 @@ class Parser {
             $s9 = $this->peg_FAILED;
           }
           if ($s9 !== $this->peg_FAILED) {
-            $s10 = $this->peg_c16;
+            $s10 = $this->peg_c25;
             if ($s10 !== $this->peg_FAILED) {
-              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                $s11 = $this->peg_c10;
+              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                $s11 = $this->peg_c15;
                 $this->peg_currPos++;
               } else {
                 $s11 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c11);
+                    $this->peg_fail($this->peg_c16);
                 }
               }
               if ($s11 === $this->peg_FAILED) {
                 $s11 = null;
               }
               if ($s11 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s12 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s12 !== $this->peg_FAILED) {
@@ -1133,7 +1696,7 @@ class Parser {
           } else {
             $s7 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c17);
+                $this->peg_fail($this->peg_c0);
             }
           }
           if ($s7 !== $this->peg_FAILED) {
@@ -1153,13 +1716,13 @@ class Parser {
           $s6 = $this->peg_currPos;
           $this->peg_silentFails++;
           $s7 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s8 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s8 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s8 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s8 !== $this->peg_FAILED) {
@@ -1174,28 +1737,28 @@ class Parser {
               $s9 = $this->peg_FAILED;
             }
             if ($s9 !== $this->peg_FAILED) {
-              $s10 = $this->peg_c16;
+              $s10 = $this->peg_c25;
               if ($s10 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                  $s11 = $this->peg_c10;
+                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                  $s11 = $this->peg_c15;
                   $this->peg_currPos++;
                 } else {
                   $s11 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c11);
+                      $this->peg_fail($this->peg_c16);
                   }
                 }
                 if ($s11 === $this->peg_FAILED) {
                   $s11 = null;
                 }
                 if ($s11 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s12 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s12 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s12 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s12 !== $this->peg_FAILED) {
@@ -1235,7 +1798,7 @@ class Parser {
             } else {
               $s7 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c17);
+                  $this->peg_fail($this->peg_c0);
               }
             }
             if ($s7 !== $this->peg_FAILED) {
@@ -1251,13 +1814,13 @@ class Parser {
           }
         }
         if ($s4 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s5 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s5 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s5 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s5 !== $this->peg_FAILED) {
@@ -1282,7 +1845,7 @@ class Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f9($s1);
+        $s1 = $this->peg_f10($s1);
       }
       $s0 = $s1;
 
@@ -1291,132 +1854,9 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseASCII_AlphaNumeric() {
-
-      $key    = $this->peg_currPos * 19 + 10;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      $s0 = $this->peg_parseASCII_Letter();
-      if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseASCII_Digit();
-        if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseSpecial_Chars();
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Letter() {
-
-      $key    = $this->peg_currPos * 19 + 11;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      if (peg_regex_test($this->peg_c18, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c19);
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Digit() {
-
-      $key    = $this->peg_currPos * 19 + 12;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      if (peg_regex_test($this->peg_c20, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c21);
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseSpecial_Chars() {
-
-      $key    = $this->peg_currPos * 19 + 13;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      if (peg_regex_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c23);
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
     private function peg_parseWS() {
 
-      $key    = $this->peg_currPos * 19 + 14;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      if (peg_regex_test($this->peg_c24, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c25);
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseNewline() {
-
-      $key    = $this->peg_currPos * 19 + 15;
+      $key    = $this->peg_currPos * 17 + 12;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -1439,9 +1879,9 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parse_() {
+    private function peg_parseNewline() {
 
-      $key    = $this->peg_currPos * 19 + 16;
+      $key    = $this->peg_currPos * 17 + 13;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -1464,9 +1904,34 @@ class Parser {
       return $s0;
     }
 
+    private function peg_parse_() {
+
+      $key    = $this->peg_currPos * 17 + 14;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      if (peg_regex_test($this->peg_c30, $this->input_substr($this->peg_currPos, 1))) {
+        $s0 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s0 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c31);
+        }
+      }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
     private function peg_parse__() {
 
-      $key    = $this->peg_currPos * 19 + 17;
+      $key    = $this->peg_currPos * 17 + 15;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -1492,7 +1957,7 @@ class Parser {
 
     private function peg_parseAny() {
 
-      $key    = $this->peg_currPos * 19 + 18;
+      $key    = $this->peg_currPos * 17 + 16;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -1506,7 +1971,7 @@ class Parser {
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c17);
+            $this->peg_fail($this->peg_c0);
         }
       }
 
@@ -1532,39 +1997,41 @@ class Parser {
     mb_regex_encoding("UTF-8");
 
     $this->peg_FAILED = new \stdClass;
-    $this->peg_c0 = "<!--";
-    $this->peg_c1 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
-    $this->peg_c2 = "wp:";
-    $this->peg_c3 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
-    $this->peg_c4 = "/-->";
-    $this->peg_c5 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
-    $this->peg_c6 = "-->";
-    $this->peg_c7 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
-    $this->peg_c8 = "/wp:";
-    $this->peg_c9 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
-    $this->peg_c10 = "/";
-    $this->peg_c11 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
-    $this->peg_c12 = "{";
-    $this->peg_c13 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
-    $this->peg_c14 = "}";
-    $this->peg_c15 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
-    $this->peg_c16 = "";
-    $this->peg_c17 = array("type" => "any", "description" => "any character" );
-    $this->peg_c18 = "/^[a-zA-Z]/";
-    $this->peg_c19 = array( "type" => "class", "value" => "[a-zA-Z]", "description" => "[a-zA-Z]" );
-    $this->peg_c20 = "/^[0-9]/";
-    $this->peg_c21 = array( "type" => "class", "value" => "[0-9]", "description" => "[0-9]" );
-    $this->peg_c22 = "/^[-_]/";
-    $this->peg_c23 = array( "type" => "class", "value" => "[-_]", "description" => "[-_]" );
-    $this->peg_c24 = "/^[ \\t\\r\\n]/";
-    $this->peg_c25 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
-    $this->peg_c26 = "/^[\\r\\n]/";
-    $this->peg_c27 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
-    $this->peg_c28 = "/^[ \\t]/";
-    $this->peg_c29 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
+    $this->peg_c0 = array("type" => "any", "description" => "any character" );
+    $this->peg_c1 = "<!--";
+    $this->peg_c2 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
+    $this->peg_c3 = "more";
+    $this->peg_c4 = array( "type" => "literal", "value" => "more", "description" => "\"more\"" );
+    $this->peg_c5 = "-->";
+    $this->peg_c6 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
+    $this->peg_c7 = "<!--noteaser-->";
+    $this->peg_c8 = array( "type" => "literal", "value" => "<!--noteaser-->", "description" => "\"<!--noteaser-->\"" );
+    $this->peg_c9 = "wp:";
+    $this->peg_c10 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
+    $this->peg_c11 = "/-->";
+    $this->peg_c12 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
+    $this->peg_c13 = "/wp:";
+    $this->peg_c14 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
+    $this->peg_c15 = "/";
+    $this->peg_c16 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
+    $this->peg_c17 = "/^[a-z]/";
+    $this->peg_c18 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
+    $this->peg_c19 = "/^[a-z0-9_-]/";
+    $this->peg_c20 = array( "type" => "class", "value" => "[a-z0-9_-]", "description" => "[a-z0-9_-]" );
+    $this->peg_c21 = "{";
+    $this->peg_c22 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
+    $this->peg_c23 = "}";
+    $this->peg_c24 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
+    $this->peg_c25 = "";
+    $this->peg_c26 = "/^[ \\t\\r\\n]/";
+    $this->peg_c27 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
+    $this->peg_c28 = "/^[\\r\\n]/";
+    $this->peg_c29 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
+    $this->peg_c30 = "/^[ \\t]/";
+    $this->peg_c31 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
 
-    $peg_startRuleFunctions = array( 'Document' => array($this, "peg_parseDocument") );
-    $peg_startRuleFunction  = array($this, "peg_parseDocument");
+    $peg_startRuleFunctions = array( 'Block_List' => array($this, "peg_parseBlock_List") );
+    $peg_startRuleFunction  = array($this, "peg_parseBlock_List");
     if (isset($options["startRule"])) {
       if (!(isset($peg_startRuleFunctions[$options["startRule"]]))) {
         throw new \Exception("Can't start parsing from rule \"" + $options["startRule"] + "\".");
@@ -1577,6 +2044,49 @@ class Parser {
 
     // The `maybeJSON` function is not needed in PHP because its return semantics
     // are the same as `json_decode`
+
+    // array arguments are backwards because of PHP
+    if ( ! function_exists( 'peg_array_partition' ) ) {
+        function peg_array_partition( $array, $predicate ) {
+            $truthy = array();
+            $falsey = array();
+
+            foreach ( $array as $item ) {
+                call_user_func( $predicate, $item )
+                    ? $truthy[] = $item
+                    : $falsey[] = $item;
+            }
+
+            return array( $truthy, $falsey );
+        }
+    }
+
+    if ( ! function_exists( 'peg_join_blocks' ) ) {
+        function peg_join_blocks( $pre, $tokens, $post ) {
+            $blocks = array();
+
+            if ( ! empty( $pre ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+            }
+
+            foreach ( $tokens as $token ) {
+                list( $token, $html ) = $token;
+
+                $blocks[] = $token;
+
+                if ( ! empty( $html ) ) {
+                    $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+                }
+            }
+
+            if ( ! empty( $post ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+            }
+
+            return $blocks;
+        }
+    }
+
 
     /* END initializer code */
 

--- a/test/fixtures/wp-gutenberg-post-cached.php52.php
+++ b/test/fixtures/wp-gutenberg-post-cached.php52.php
@@ -101,7 +101,7 @@ class php52_compat_Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {
@@ -257,29 +257,43 @@ class php52_compat_Parser {
     private $peg_c27;
     private $peg_c28;
     private $peg_c29;
+    private $peg_c30;
+    private $peg_c31;
 
-    private function peg_f0($blockName, $a) { return $a; }
-    private function peg_f1($blockName, $attrs) {
+    private function peg_f0($pre, $t, $html) { return array( $t, $html ); }
+    private function peg_f1($pre, $ts, $post) { return peg_join_blocks( $pre, $ts, $post ); }
+    private function peg_f2($text) { return $text; }
+    private function peg_f3($customText, $noTeaser) {
+        $attrs = array( 'noTeaser' => (bool) $noTeaser );
+        if ( ! empty( $customText ) ) {
+          $attrs['customText'] = $customText;
+        }
+        return array(
+           'blockName' => 'core/more',
+           'attrs' => $attrs,
+           'innerHTML' => '',
+           'outerHTML' => $this->text(),
+        );
+        }
+    private function peg_f4($blockName, $a) { return $a; }
+    private function peg_f5($blockName, $attrs) {
         return array(
           'blockName'  => $blockName,
           'attrs'      => $attrs,
-          'rawContent' => '',
+          'innerBlocks' => array(),
+          'innerHTML' => '',
+          'outerHTML' => $this->text(),
         );
         }
-    private function peg_f2($s, $c) { return $c; }
-    private function peg_f3($s, $ts, $e) { return $s['blockName'] === $e['blockName']; }
-    private function peg_f4($s, $ts, $e) {
+    private function peg_f6($s, $children, $e) {
+        list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+
         return array(
           'blockName'  => $s['blockName'],
           'attrs'      => $s['attrs'],
-          'rawContent' => implode( '', $ts ),
-        );
-        }
-    private function peg_f5($c) { return $c; }
-    private function peg_f6($ts) {
-        return array(
-          'attrs'      => array(),
-          'rawContent' => implode( '', $ts ),
+          'innerBlocks'  => $innerBlocks,
+          'innerHTML'  => implode( '', $innerHTML ),
+          'outerHTML' => $this->text(),
         );
         }
     private function peg_f7($blockName, $attrs) {
@@ -293,73 +307,12 @@ class php52_compat_Parser {
           'blockName' => $blockName,
         );
         }
-    private function peg_f9($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f9($type) { return "core/$type"; }
+    private function peg_f10($attrs) { return json_decode( $attrs, true ); }
 
-    private function peg_parseDocument() {
+    private function peg_parseBlock_List() {
 
-      $key    = $this->peg_currPos * 19 + 0;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      $s0 = $this->peg_parseWP_Block_List();
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block_List() {
-
-      $key    = $this->peg_currPos * 19 + 1;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      $s0 = array();
-      $s1 = $this->peg_parseWP_Block();
-      while ($s1 !== $this->peg_FAILED) {
-        $s0[] = $s1;
-        $s1 = $this->peg_parseWP_Block();
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block() {
-
-      $key    = $this->peg_currPos * 19 + 2;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      $s0 = $this->peg_parseWP_Block_Void();
-      if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseWP_Block_Balanced();
-        if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseWP_Block_Html();
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block_Void() {
-
-      $key    = $this->peg_currPos * 19 + 3;
+      $key    = $this->peg_currPos * 17 + 0;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -368,91 +321,586 @@ class php52_compat_Parser {
       }
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      $s1 = $this->peg_currPos;
+      $s2 = array();
+      $s3 = $this->peg_currPos;
+      $s4 = $this->peg_currPos;
+      $this->peg_silentFails++;
+      $s5 = $this->peg_parseToken();
+      $this->peg_silentFails--;
+      if ($s5 === $this->peg_FAILED) {
+        $s4 = null;
+      } else {
+        $this->peg_currPos = $s4;
+        $s4 = $this->peg_FAILED;
+      }
+      if ($s4 !== $this->peg_FAILED) {
+        if ($this->input_length > $this->peg_currPos) {
+          $s5 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s5 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c0);
+          }
+        }
+        if ($s5 !== $this->peg_FAILED) {
+          $s4 = array($s4, $s5);
+          $s3 = $s4;
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s3;
+        $s3 = $this->peg_FAILED;
+      }
+      while ($s3 !== $this->peg_FAILED) {
+        $s2[] = $s3;
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_currPos;
+        $this->peg_silentFails++;
+        $s5 = $this->peg_parseToken();
+        $this->peg_silentFails--;
+        if ($s5 === $this->peg_FAILED) {
+          $s4 = null;
+        } else {
+          $this->peg_currPos = $s4;
+          $s4 = $this->peg_FAILED;
+        }
+        if ($s4 !== $this->peg_FAILED) {
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $s4 = array($s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      }
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_parseToken();
+        if ($s4 !== $this->peg_FAILED) {
+          $s5 = $this->peg_currPos;
+          $s6 = array();
+          $s7 = $this->peg_currPos;
+          $s8 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          $s9 = $this->peg_parseToken();
+          $this->peg_silentFails--;
+          if ($s9 === $this->peg_FAILED) {
+            $s8 = null;
+          } else {
+            $this->peg_currPos = $s8;
+            $s8 = $this->peg_FAILED;
+          }
+          if ($s8 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s9 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s9 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s9 !== $this->peg_FAILED) {
+              $s8 = array($s8, $s9);
+              $s7 = $s8;
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s7;
+            $s7 = $this->peg_FAILED;
+          }
+          while ($s7 !== $this->peg_FAILED) {
+            $s6[] = $s7;
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          }
+          if ($s6 !== $this->peg_FAILED) {
+            $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+          } else {
+            $s5 = $s6;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s3;
+            $s4 = $this->peg_f0($s1, $s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_currPos;
+          $s4 = $this->peg_parseToken();
+          if ($s4 !== $this->peg_FAILED) {
+            $s5 = $this->peg_currPos;
+            $s6 = array();
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+            while ($s7 !== $this->peg_FAILED) {
+              $s6[] = $s7;
+              $s7 = $this->peg_currPos;
+              $s8 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s9 = $this->peg_parseToken();
+              $this->peg_silentFails--;
+              if ($s9 === $this->peg_FAILED) {
+                $s8 = null;
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s9 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s9 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s9 !== $this->peg_FAILED) {
+                  $s8 = array($s8, $s9);
+                  $s7 = $s8;
+                } else {
+                  $this->peg_currPos = $s7;
+                  $s7 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+            } else {
+              $s5 = $s6;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s3;
+              $s4 = $this->peg_f0($s1, $s4, $s5);
+              $s3 = $s4;
+            } else {
+              $this->peg_currPos = $s3;
+              $s3 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_currPos;
+          $s4 = array();
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          while ($s5 !== $this->peg_FAILED) {
+            $s4[] = $s5;
+            if ($this->input_length > $this->peg_currPos) {
+              $s5 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s5 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f1($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
+      }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
+    private function peg_parseToken() {
+
+      $key    = $this->peg_currPos * 17 + 1;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      $s0 = $this->peg_parseTag_More();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_parseBlock_Void();
+        if ($s0 === $this->peg_FAILED) {
+          $s0 = $this->peg_parseBlock_Balanced();
+        }
+      }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
+    private function peg_parseTag_More() {
+
+      $key    = $this->peg_currPos * 17 + 2;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      $s0 = $this->peg_currPos;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
         $s3 = $this->peg_parseWS();
-        if ($s3 !== $this->peg_FAILED) {
-          while ($s3 !== $this->peg_FAILED) {
-            $s2[] = $s3;
-            $s3 = $this->peg_parseWS();
-          }
-        } else {
-          $s2 = $this->peg_FAILED;
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseWS();
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
-            $this->peg_currPos += 3;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c3) {
+            $s3 = $this->peg_c3;
+            $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c4);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_currPos;
+            $s5 = array();
+            $s6 = $this->peg_parseWS();
+            if ($s6 !== $this->peg_FAILED) {
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
+              }
+            } else {
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $s6 = $this->peg_currPos;
+              $s7 = array();
+              $s8 = $this->peg_currPos;
+              $s9 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s10 = $this->peg_currPos;
+              $s11 = array();
+              $s12 = $this->peg_parseWS();
+              while ($s12 !== $this->peg_FAILED) {
+                $s11[] = $s12;
+                $s12 = $this->peg_parseWS();
+              }
+              if ($s11 !== $this->peg_FAILED) {
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
+                  $this->peg_currPos += 3;
+                } else {
+                  $s12 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
+                }
+                if ($s12 !== $this->peg_FAILED) {
+                  $s11 = array($s11, $s12);
+                  $s10 = $s11;
+                } else {
+                  $this->peg_currPos = $s10;
+                  $s10 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s10;
+                $s10 = $this->peg_FAILED;
+              }
+              $this->peg_silentFails--;
+              if ($s10 === $this->peg_FAILED) {
+                $s9 = null;
+              } else {
+                $this->peg_currPos = $s9;
+                $s9 = $this->peg_FAILED;
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s10 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s10 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s10 !== $this->peg_FAILED) {
+                  $s9 = array($s9, $s10);
+                  $s8 = $s9;
+                } else {
+                  $this->peg_currPos = $s8;
+                  $s8 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                while ($s8 !== $this->peg_FAILED) {
+                  $s7[] = $s8;
+                  $s8 = $this->peg_currPos;
+                  $s9 = $this->peg_currPos;
+                  $this->peg_silentFails++;
+                  $s10 = $this->peg_currPos;
+                  $s11 = array();
+                  $s12 = $this->peg_parseWS();
+                  while ($s12 !== $this->peg_FAILED) {
+                    $s11[] = $s12;
+                    $s12 = $this->peg_parseWS();
+                  }
+                  if ($s11 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                      $s12 = $this->peg_c5;
+                      $this->peg_currPos += 3;
+                    } else {
+                      $s12 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c6);
+                      }
+                    }
+                    if ($s12 !== $this->peg_FAILED) {
+                      $s11 = array($s11, $s12);
+                      $s10 = $s11;
+                    } else {
+                      $this->peg_currPos = $s10;
+                      $s10 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s10;
+                    $s10 = $this->peg_FAILED;
+                  }
+                  $this->peg_silentFails--;
+                  if ($s10 === $this->peg_FAILED) {
+                    $s9 = null;
+                  } else {
+                    $this->peg_currPos = $s9;
+                    $s9 = $this->peg_FAILED;
+                  }
+                  if ($s9 !== $this->peg_FAILED) {
+                    if ($this->input_length > $this->peg_currPos) {
+                      $s10 = $this->input_substr($this->peg_currPos, 1);
+                      $this->peg_currPos++;
+                    } else {
+                      $s10 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c0);
+                      }
+                    }
+                    if ($s10 !== $this->peg_FAILED) {
+                      $s9 = array($s9, $s10);
+                      $s8 = $s9;
+                    } else {
+                      $this->peg_currPos = $s8;
+                      $s8 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s8;
+                    $s8 = $this->peg_FAILED;
+                  }
+                }
+              } else {
+                $s7 = $this->peg_FAILED;
+              }
+              if ($s7 !== $this->peg_FAILED) {
+                $s6 = $this->input_substr($s6, $this->peg_currPos - $s6);
+              } else {
+                $s6 = $s7;
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $this->peg_reportedPos = $s4;
+                $s5 = $this->peg_f2($s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+            if ($s4 === $this->peg_FAILED) {
+              $s4 = null;
+            }
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
-              if ($s6 !== $this->peg_FAILED) {
-                while ($s6 !== $this->peg_FAILED) {
-                  $s5[] = $s6;
-                  $s6 = $this->peg_parseWS();
-                }
-              } else {
-                $s5 = $this->peg_FAILED;
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
               }
               if ($s5 !== $this->peg_FAILED) {
-                $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
-                if ($s7 !== $this->peg_FAILED) {
-                  $s8 = array();
-                  $s9 = $this->peg_parseWS();
-                  if ($s9 !== $this->peg_FAILED) {
-                    while ($s9 !== $this->peg_FAILED) {
-                      $s8[] = $s9;
-                      $s9 = $this->peg_parseWS();
-                    }
-                  } else {
-                    $s8 = $this->peg_FAILED;
-                  }
-                  if ($s8 !== $this->peg_FAILED) {
-                    $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
-                    $s6 = $s7;
-                  } else {
-                    $this->peg_currPos = $s6;
-                    $s6 = $this->peg_FAILED;
-                  }
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
+                  $this->peg_currPos += 3;
                 } else {
-                  $this->peg_currPos = $s6;
                   $s6 = $this->peg_FAILED;
-                }
-                if ($s6 === $this->peg_FAILED) {
-                  $s6 = null;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c4) {
-                    $s7 = $this->peg_c4;
-                    $this->peg_currPos += 4;
-                  } else {
-                    $s7 = $this->peg_FAILED;
-                    if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c5);
+                  $s7 = $this->peg_currPos;
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  while ($s9 !== $this->peg_FAILED) {
+                    $s8[] = $s9;
+                    $s9 = $this->peg_parseWS();
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 15) === $this->peg_c7) {
+                      $s9 = $this->peg_c7;
+                      $this->peg_currPos += 15;
+                    } else {
+                      $s9 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c8);
+                      }
                     }
+                    if ($s9 !== $this->peg_FAILED) {
+                      $s8 = array($s8, $s9);
+                      $s7 = $s8;
+                    } else {
+                      $this->peg_currPos = $s7;
+                      $s7 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s7;
+                    $s7 = $this->peg_FAILED;
+                  }
+                  if ($s7 === $this->peg_FAILED) {
+                    $s7 = null;
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f1($s4, $s6);
+                    $s1 = $this->peg_f3($s4, $s7);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -488,9 +936,9 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Balanced() {
+    private function peg_parseBlock_Void() {
 
-      $key    = $this->peg_currPos * 19 + 4;
+      $key    = $this->peg_currPos * 17 + 3;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -499,76 +947,104 @@ class php52_compat_Parser {
       }
 
       $s0 = $this->peg_currPos;
-      $s1 = $this->peg_parseWP_Block_Start();
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
+        $this->peg_currPos += 4;
+      } else {
+        $s1 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c2);
+        }
+      }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
-        $s3 = $this->peg_currPos;
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_End();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s3;
-            $s4 = $this->peg_f2($s1, $s5);
-            $s3 = $s4;
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+        $s3 = $this->peg_parseWS();
+        if ($s3 !== $this->peg_FAILED) {
+          while ($s3 !== $this->peg_FAILED) {
+            $s2[] = $s3;
+            $s3 = $this->peg_parseWS();
           }
         } else {
-          $this->peg_currPos = $s3;
-          $s3 = $this->peg_FAILED;
-        }
-        while ($s3 !== $this->peg_FAILED) {
-          $s2[] = $s3;
-          $s3 = $this->peg_currPos;
-          $s4 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s5 = $this->peg_parseWP_Block_End();
-          $this->peg_silentFails--;
-          if ($s5 === $this->peg_FAILED) {
-            $s4 = null;
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
-          }
-          if ($s4 !== $this->peg_FAILED) {
-            $s5 = $this->peg_parseAny();
-            if ($s5 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s3;
-              $s4 = $this->peg_f2($s1, $s5);
-              $s3 = $s4;
-            } else {
-              $this->peg_currPos = $s3;
-              $s3 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
-          }
+          $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          $s3 = $this->peg_parseWP_Block_End();
-          if ($s3 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $this->peg_currPos;
-            $s4 = $this->peg_f3($s1, $s2, $s3);
-            if ($s4) {
-              $s4 = null;
-            } else {
-              $s4 = $this->peg_FAILED;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
+            $this->peg_currPos += 3;
+          } else {
+            $s3 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c10);
             }
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s0;
-              $s1 = $this->peg_f4($s1, $s2, $s3);
-              $s0 = $s1;
+              $s5 = array();
+              $s6 = $this->peg_parseWS();
+              if ($s6 !== $this->peg_FAILED) {
+                while ($s6 !== $this->peg_FAILED) {
+                  $s5[] = $s6;
+                  $s6 = $this->peg_parseWS();
+                }
+              } else {
+                $s5 = $this->peg_FAILED;
+              }
+              if ($s5 !== $this->peg_FAILED) {
+                $s6 = $this->peg_currPos;
+                $s7 = $this->peg_parseBlock_Attributes();
+                if ($s7 !== $this->peg_FAILED) {
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  if ($s9 !== $this->peg_FAILED) {
+                    while ($s9 !== $this->peg_FAILED) {
+                      $s8[] = $s9;
+                      $s9 = $this->peg_parseWS();
+                    }
+                  } else {
+                    $s8 = $this->peg_FAILED;
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s6;
+                    $s7 = $this->peg_f4($s4, $s7);
+                    $s6 = $s7;
+                  } else {
+                    $this->peg_currPos = $s6;
+                    $s6 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s6;
+                  $s6 = $this->peg_FAILED;
+                }
+                if ($s6 === $this->peg_FAILED) {
+                  $s6 = null;
+                }
+                if ($s6 !== $this->peg_FAILED) {
+                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c11) {
+                    $s7 = $this->peg_c11;
+                    $this->peg_currPos += 4;
+                  } else {
+                    $s7 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c12);
+                    }
+                  }
+                  if ($s7 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s0;
+                    $s1 = $this->peg_f5($s4, $s6);
+                    $s0 = $s1;
+                  } else {
+                    $this->peg_currPos = $s0;
+                    $s0 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s0;
+                  $s0 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s0;
+                $s0 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s0;
               $s0 = $this->peg_FAILED;
@@ -591,9 +1067,9 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Html() {
+    private function peg_parseBlock_Balanced() {
 
-      $key    = $this->peg_currPos * 19 + 5;
+      $key    = $this->peg_currPos * 17 + 4;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -602,108 +1078,121 @@ class php52_compat_Parser {
       }
 
       $s0 = $this->peg_currPos;
-      $s1 = array();
-      $s2 = $this->peg_currPos;
-      $s3 = $this->peg_currPos;
-      $this->peg_silentFails++;
-      $s4 = $this->peg_parseWP_Block_Balanced();
-      $this->peg_silentFails--;
-      if ($s4 === $this->peg_FAILED) {
-        $s3 = null;
-      } else {
-        $this->peg_currPos = $s3;
-        $s3 = $this->peg_FAILED;
-      }
-      if ($s3 !== $this->peg_FAILED) {
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_Void();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s2;
-            $s3 = $this->peg_f5($s5);
-            $s2 = $s3;
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
-          }
-        } else {
-          $this->peg_currPos = $s2;
-          $s2 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s2;
-        $s2 = $this->peg_FAILED;
-      }
-      if ($s2 !== $this->peg_FAILED) {
-        while ($s2 !== $this->peg_FAILED) {
-          $s1[] = $s2;
-          $s2 = $this->peg_currPos;
+      $s1 = $this->peg_parseBlock_Start();
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_parseToken();
+        if ($s3 === $this->peg_FAILED) {
           $s3 = $this->peg_currPos;
+          $s4 = $this->peg_currPos;
+          $s5 = $this->peg_currPos;
           $this->peg_silentFails++;
-          $s4 = $this->peg_parseWP_Block_Balanced();
+          $s6 = $this->peg_parseBlock_End();
           $this->peg_silentFails--;
-          if ($s4 === $this->peg_FAILED) {
-            $s3 = null;
+          if ($s6 === $this->peg_FAILED) {
+            $s5 = null;
           } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
           }
-          if ($s3 !== $this->peg_FAILED) {
+          if ($s5 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s6 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s6 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = array($s5, $s6);
+              $s4 = $s5;
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseToken();
+          if ($s3 === $this->peg_FAILED) {
+            $s3 = $this->peg_currPos;
             $s4 = $this->peg_currPos;
+            $s5 = $this->peg_currPos;
             $this->peg_silentFails++;
-            $s5 = $this->peg_parseWP_Block_Void();
+            $s6 = $this->peg_parseBlock_End();
             $this->peg_silentFails--;
-            if ($s5 === $this->peg_FAILED) {
-              $s4 = null;
+            if ($s6 === $this->peg_FAILED) {
+              $s5 = null;
+            } else {
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s6 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s6 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $s5 = array($s5, $s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s4;
               $s4 = $this->peg_FAILED;
             }
             if ($s4 !== $this->peg_FAILED) {
-              $s5 = $this->peg_parseAny();
-              if ($s5 !== $this->peg_FAILED) {
-                $this->peg_reportedPos = $s2;
-                $s3 = $this->peg_f5($s5);
-                $s2 = $s3;
-              } else {
-                $this->peg_currPos = $s2;
-                $s2 = $this->peg_FAILED;
-              }
+              $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
             } else {
-              $this->peg_currPos = $s2;
-              $s2 = $this->peg_FAILED;
+              $s3 = $s4;
             }
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
           }
         }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_parseBlock_End();
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f6($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
       } else {
-        $s1 = $this->peg_FAILED;
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
-      if ($s1 !== $this->peg_FAILED) {
-        $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f6($s1);
-      }
-      $s0 = $s1;
 
       $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
 
       return $s0;
     }
 
-    private function peg_parseWP_Block_Start() {
+    private function peg_parseBlock_Start() {
 
-      $key    = $this->peg_currPos * 19 + 6;
+      $key    = $this->peg_currPos * 17 + 5;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -712,13 +1201,13 @@ class php52_compat_Parser {
       }
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -733,17 +1222,17 @@ class php52_compat_Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
             $this->peg_currPos += 3;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c10);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -757,7 +1246,7 @@ class php52_compat_Parser {
               }
               if ($s5 !== $this->peg_FAILED) {
                 $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
+                $s7 = $this->peg_parseBlock_Attributes();
                 if ($s7 !== $this->peg_FAILED) {
                   $s8 = array();
                   $s9 = $this->peg_parseWS();
@@ -771,7 +1260,7 @@ class php52_compat_Parser {
                   }
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
+                    $s7 = $this->peg_f4($s4, $s7);
                     $s6 = $s7;
                   } else {
                     $this->peg_currPos = $s6;
@@ -785,13 +1274,13 @@ class php52_compat_Parser {
                   $s6 = null;
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s7 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s7 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s7 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s7 !== $this->peg_FAILED) {
@@ -832,9 +1321,9 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_End() {
+    private function peg_parseBlock_End() {
 
-      $key    = $this->peg_currPos * 19 + 7;
+      $key    = $this->peg_currPos * 17 + 6;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -843,13 +1332,13 @@ class php52_compat_Parser {
       }
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -864,17 +1353,17 @@ class php52_compat_Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c8) {
-            $s3 = $this->peg_c8;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c13) {
+            $s3 = $this->peg_c13;
             $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c9);
+                $this->peg_fail($this->peg_c14);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -887,13 +1376,13 @@ class php52_compat_Parser {
                 $s5 = $this->peg_FAILED;
               }
               if ($s5 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s6 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s6 !== $this->peg_FAILED) {
@@ -930,9 +1419,29 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Name() {
+    private function peg_parseBlock_Name() {
 
-      $key    = $this->peg_currPos * 19 + 8;
+      $key    = $this->peg_currPos * 17 + 7;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      $s0 = $this->peg_parseNamespaced_Block_Name();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_parseCore_Block_Name();
+      }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
+    private function peg_parseNamespaced_Block_Name() {
+
+      $key    = $this->peg_currPos * 17 + 8;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -942,61 +1451,115 @@ class php52_compat_Parser {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
-      $s2 = $this->peg_parseASCII_Letter();
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+          $s3 = $this->peg_c15;
+          $this->peg_currPos++;
+        } else {
+          $s3 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c16);
+          }
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s4 = $this->peg_parseBlock_Name_Part();
+          if ($s4 !== $this->peg_FAILED) {
+            $s2 = array($s2, $s3, $s4);
+            $s1 = $s2;
+          } else {
+            $this->peg_currPos = $s1;
+            $s1 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s1;
+          $s1 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s1;
+        $s1 = $this->peg_FAILED;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+      } else {
+        $s0 = $s1;
+      }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
+    private function peg_parseCore_Block_Name() {
+
+      $key    = $this->peg_currPos * 17 + 9;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $s0;
+        $s1 = $this->peg_f9($s1);
+      }
+      $s0 = $s1;
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
+    private function peg_parseBlock_Name_Part() {
+
+      $key    = $this->peg_currPos * 17 + 10;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      if (php52_compat_peg_regex_test($this->peg_c17, $this->input_substr($this->peg_currPos, 1))) {
+        $s2 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s2 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c18);
+        }
+      }
       if ($s2 !== $this->peg_FAILED) {
         $s3 = array();
-        $s4 = $this->peg_parseASCII_AlphaNumeric();
-        if ($s4 === $this->peg_FAILED) {
-          $s4 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-            $s5 = $this->peg_c10;
-            $this->peg_currPos++;
-          } else {
-            $s5 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c11);
-            }
-          }
-          if ($s5 !== $this->peg_FAILED) {
-            $s6 = $this->peg_parseASCII_AlphaNumeric();
-            if ($s6 !== $this->peg_FAILED) {
-              $s5 = array($s5, $s6);
-              $s4 = $s5;
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
+        if (php52_compat_peg_regex_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+          $s4 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s4 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c20);
           }
         }
         while ($s4 !== $this->peg_FAILED) {
           $s3[] = $s4;
-          $s4 = $this->peg_parseASCII_AlphaNumeric();
-          if ($s4 === $this->peg_FAILED) {
-            $s4 = $this->peg_currPos;
-            if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-              $s5 = $this->peg_c10;
-              $this->peg_currPos++;
-            } else {
-              $s5 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c11);
-              }
-            }
-            if ($s5 !== $this->peg_FAILED) {
-              $s6 = $this->peg_parseASCII_AlphaNumeric();
-              if ($s6 !== $this->peg_FAILED) {
-                $s5 = array($s5, $s6);
-                $s4 = $s5;
-              } else {
-                $this->peg_currPos = $s4;
-                $s4 = $this->peg_FAILED;
-              }
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
+          if (php52_compat_peg_regex_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+            $s4 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s4 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c20);
             }
           }
         }
@@ -1022,9 +1585,9 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Attributes() {
+    private function peg_parseBlock_Attributes() {
 
-      $key    = $this->peg_currPos * 19 + 9;
+      $key    = $this->peg_currPos * 17 + 11;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -1035,13 +1598,13 @@ class php52_compat_Parser {
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c12) {
-        $s3 = $this->peg_c12;
+      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c21) {
+        $s3 = $this->peg_c21;
         $this->peg_currPos++;
       } else {
         $s3 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c13);
+            $this->peg_fail($this->peg_c22);
         }
       }
       if ($s3 !== $this->peg_FAILED) {
@@ -1050,13 +1613,13 @@ class php52_compat_Parser {
         $s6 = $this->peg_currPos;
         $this->peg_silentFails++;
         $s7 = $this->peg_currPos;
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-          $s8 = $this->peg_c14;
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+          $s8 = $this->peg_c23;
           $this->peg_currPos++;
         } else {
           $s8 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c15);
+              $this->peg_fail($this->peg_c24);
           }
         }
         if ($s8 !== $this->peg_FAILED) {
@@ -1071,28 +1634,28 @@ class php52_compat_Parser {
             $s9 = $this->peg_FAILED;
           }
           if ($s9 !== $this->peg_FAILED) {
-            $s10 = $this->peg_c16;
+            $s10 = $this->peg_c25;
             if ($s10 !== $this->peg_FAILED) {
-              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                $s11 = $this->peg_c10;
+              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                $s11 = $this->peg_c15;
                 $this->peg_currPos++;
               } else {
                 $s11 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c11);
+                    $this->peg_fail($this->peg_c16);
                 }
               }
               if ($s11 === $this->peg_FAILED) {
                 $s11 = null;
               }
               if ($s11 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s12 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s12 !== $this->peg_FAILED) {
@@ -1132,7 +1695,7 @@ class php52_compat_Parser {
           } else {
             $s7 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c17);
+                $this->peg_fail($this->peg_c0);
             }
           }
           if ($s7 !== $this->peg_FAILED) {
@@ -1152,13 +1715,13 @@ class php52_compat_Parser {
           $s6 = $this->peg_currPos;
           $this->peg_silentFails++;
           $s7 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s8 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s8 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s8 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s8 !== $this->peg_FAILED) {
@@ -1173,28 +1736,28 @@ class php52_compat_Parser {
               $s9 = $this->peg_FAILED;
             }
             if ($s9 !== $this->peg_FAILED) {
-              $s10 = $this->peg_c16;
+              $s10 = $this->peg_c25;
               if ($s10 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                  $s11 = $this->peg_c10;
+                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                  $s11 = $this->peg_c15;
                   $this->peg_currPos++;
                 } else {
                   $s11 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c11);
+                      $this->peg_fail($this->peg_c16);
                   }
                 }
                 if ($s11 === $this->peg_FAILED) {
                   $s11 = null;
                 }
                 if ($s11 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s12 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s12 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s12 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s12 !== $this->peg_FAILED) {
@@ -1234,7 +1797,7 @@ class php52_compat_Parser {
             } else {
               $s7 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c17);
+                  $this->peg_fail($this->peg_c0);
               }
             }
             if ($s7 !== $this->peg_FAILED) {
@@ -1250,13 +1813,13 @@ class php52_compat_Parser {
           }
         }
         if ($s4 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s5 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s5 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s5 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s5 !== $this->peg_FAILED) {
@@ -1281,7 +1844,7 @@ class php52_compat_Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f9($s1);
+        $s1 = $this->peg_f10($s1);
       }
       $s0 = $s1;
 
@@ -1290,132 +1853,9 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseASCII_AlphaNumeric() {
-
-      $key    = $this->peg_currPos * 19 + 10;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      $s0 = $this->peg_parseASCII_Letter();
-      if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseASCII_Digit();
-        if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseSpecial_Chars();
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Letter() {
-
-      $key    = $this->peg_currPos * 19 + 11;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      if (php52_compat_peg_regex_test($this->peg_c18, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c19);
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Digit() {
-
-      $key    = $this->peg_currPos * 19 + 12;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      if (php52_compat_peg_regex_test($this->peg_c20, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c21);
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseSpecial_Chars() {
-
-      $key    = $this->peg_currPos * 19 + 13;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      if (php52_compat_peg_regex_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c23);
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
     private function peg_parseWS() {
 
-      $key    = $this->peg_currPos * 19 + 14;
-          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
-
-      if ($cached) {
-        $this->peg_currPos = $cached["nextPos"];
-        return $cached["result"];
-      }
-
-      if (php52_compat_peg_regex_test($this->peg_c24, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c25);
-        }
-      }
-
-      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
-
-      return $s0;
-    }
-
-    private function peg_parseNewline() {
-
-      $key    = $this->peg_currPos * 19 + 15;
+      $key    = $this->peg_currPos * 17 + 12;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -1438,9 +1878,9 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parse_() {
+    private function peg_parseNewline() {
 
-      $key    = $this->peg_currPos * 19 + 16;
+      $key    = $this->peg_currPos * 17 + 13;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -1463,9 +1903,34 @@ class php52_compat_Parser {
       return $s0;
     }
 
+    private function peg_parse_() {
+
+      $key    = $this->peg_currPos * 17 + 14;
+          $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
+
+      if ($cached) {
+        $this->peg_currPos = $cached["nextPos"];
+        return $cached["result"];
+      }
+
+      if (php52_compat_peg_regex_test($this->peg_c30, $this->input_substr($this->peg_currPos, 1))) {
+        $s0 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s0 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c31);
+        }
+      }
+
+      $this->peg_cache[$key] = array ("nextPos" => $this->peg_currPos, "result" => $s0 );
+
+      return $s0;
+    }
+
     private function peg_parse__() {
 
-      $key    = $this->peg_currPos * 19 + 17;
+      $key    = $this->peg_currPos * 17 + 15;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -1491,7 +1956,7 @@ class php52_compat_Parser {
 
     private function peg_parseAny() {
 
-      $key    = $this->peg_currPos * 19 + 18;
+      $key    = $this->peg_currPos * 17 + 16;
           $cached = isset($this->peg_cache[$key]) ? $this->peg_cache[$key] : null;
 
       if ($cached) {
@@ -1505,7 +1970,7 @@ class php52_compat_Parser {
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c17);
+            $this->peg_fail($this->peg_c0);
         }
       }
 
@@ -1531,39 +1996,41 @@ class php52_compat_Parser {
     mb_regex_encoding("UTF-8");
 
     $this->peg_FAILED = new stdClass;
-    $this->peg_c0 = "<!--";
-    $this->peg_c1 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
-    $this->peg_c2 = "wp:";
-    $this->peg_c3 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
-    $this->peg_c4 = "/-->";
-    $this->peg_c5 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
-    $this->peg_c6 = "-->";
-    $this->peg_c7 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
-    $this->peg_c8 = "/wp:";
-    $this->peg_c9 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
-    $this->peg_c10 = "/";
-    $this->peg_c11 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
-    $this->peg_c12 = "{";
-    $this->peg_c13 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
-    $this->peg_c14 = "}";
-    $this->peg_c15 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
-    $this->peg_c16 = "";
-    $this->peg_c17 = array("type" => "any", "description" => "any character" );
-    $this->peg_c18 = "/^[a-zA-Z]/";
-    $this->peg_c19 = array( "type" => "class", "value" => "[a-zA-Z]", "description" => "[a-zA-Z]" );
-    $this->peg_c20 = "/^[0-9]/";
-    $this->peg_c21 = array( "type" => "class", "value" => "[0-9]", "description" => "[0-9]" );
-    $this->peg_c22 = "/^[-_]/";
-    $this->peg_c23 = array( "type" => "class", "value" => "[-_]", "description" => "[-_]" );
-    $this->peg_c24 = "/^[ \\t\\r\\n]/";
-    $this->peg_c25 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
-    $this->peg_c26 = "/^[\\r\\n]/";
-    $this->peg_c27 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
-    $this->peg_c28 = "/^[ \\t]/";
-    $this->peg_c29 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
+    $this->peg_c0 = array("type" => "any", "description" => "any character" );
+    $this->peg_c1 = "<!--";
+    $this->peg_c2 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
+    $this->peg_c3 = "more";
+    $this->peg_c4 = array( "type" => "literal", "value" => "more", "description" => "\"more\"" );
+    $this->peg_c5 = "-->";
+    $this->peg_c6 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
+    $this->peg_c7 = "<!--noteaser-->";
+    $this->peg_c8 = array( "type" => "literal", "value" => "<!--noteaser-->", "description" => "\"<!--noteaser-->\"" );
+    $this->peg_c9 = "wp:";
+    $this->peg_c10 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
+    $this->peg_c11 = "/-->";
+    $this->peg_c12 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
+    $this->peg_c13 = "/wp:";
+    $this->peg_c14 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
+    $this->peg_c15 = "/";
+    $this->peg_c16 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
+    $this->peg_c17 = "/^[a-z]/";
+    $this->peg_c18 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
+    $this->peg_c19 = "/^[a-z0-9_-]/";
+    $this->peg_c20 = array( "type" => "class", "value" => "[a-z0-9_-]", "description" => "[a-z0-9_-]" );
+    $this->peg_c21 = "{";
+    $this->peg_c22 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
+    $this->peg_c23 = "}";
+    $this->peg_c24 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
+    $this->peg_c25 = "";
+    $this->peg_c26 = "/^[ \\t\\r\\n]/";
+    $this->peg_c27 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
+    $this->peg_c28 = "/^[\\r\\n]/";
+    $this->peg_c29 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
+    $this->peg_c30 = "/^[ \\t]/";
+    $this->peg_c31 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
 
-    $peg_startRuleFunctions = array( 'Document' => array($this, "peg_parseDocument") );
-    $peg_startRuleFunction  = array($this, "peg_parseDocument");
+    $peg_startRuleFunctions = array( 'Block_List' => array($this, "peg_parseBlock_List") );
+    $peg_startRuleFunction  = array($this, "peg_parseBlock_List");
     if (isset($options["startRule"])) {
       if (!(isset($peg_startRuleFunctions[$options["startRule"]]))) {
         throw new Exception("Can't start parsing from rule \"" + $options["startRule"] + "\".");
@@ -1576,6 +2043,49 @@ class php52_compat_Parser {
 
     // The `maybeJSON` function is not needed in PHP because its return semantics
     // are the same as `json_decode`
+
+    // array arguments are backwards because of PHP
+    if ( ! function_exists( 'peg_array_partition' ) ) {
+        function peg_array_partition( $array, $predicate ) {
+            $truthy = array();
+            $falsey = array();
+
+            foreach ( $array as $item ) {
+                call_user_func( $predicate, $item )
+                    ? $truthy[] = $item
+                    : $falsey[] = $item;
+            }
+
+            return array( $truthy, $falsey );
+        }
+    }
+
+    if ( ! function_exists( 'peg_join_blocks' ) ) {
+        function peg_join_blocks( $pre, $tokens, $post ) {
+            $blocks = array();
+
+            if ( ! empty( $pre ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+            }
+
+            foreach ( $tokens as $token ) {
+                list( $token, $html ) = $token;
+
+                $blocks[] = $token;
+
+                if ( ! empty( $html ) ) {
+                    $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+                }
+            }
+
+            if ( ! empty( $post ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+            }
+
+            return $blocks;
+        }
+    }
+
 
     /* END initializer code */
 

--- a/test/fixtures/wp-gutenberg-post-cached/example-post.json
+++ b/test/fixtures/wp-gutenberg-post-cached/example-post.json
@@ -4,28 +4,34 @@
         "attrs": {
             "align": "right"
         },
-        "rawContent": "\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n",
+        "outerHTML": "<!-- wp:text {\"align\":\"right\"} -->\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n<!-- /wp:text -->"
     },
     {
         "attrs": [],
-        "rawContent": "\n\n"
+        "innerHTML": "\n\n"
     },
     {
         "blockName": "core/separator",
         "attrs": null,
-        "rawContent": "\n<hr class=\"wp-block-separator\" />\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<hr class=\"wp-block-separator\">\n",
+        "outerHTML": "<!-- wp:separator -->\n<hr class=\"wp-block-separator\">\n<!-- /wp:separator -->"
     },
     {
         "attrs": [],
-        "rawContent": "\n\n"
+        "innerHTML": "\n\n"
     },
     {
         "blockName": "core/freeform",
         "attrs": null,
-        "rawContent": "\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n"
+        "innerBlocks": [],
+        "innerHTML": "\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n",
+        "outerHTML": "<!-- wp:freeform -->\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n<!-- /wp:freeform -->"
     },
     {
         "attrs": [],
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/test/fixtures/wp-gutenberg-post-cached/example-post.txt
+++ b/test/fixtures/wp-gutenberg-post-cached/example-post.txt
@@ -1,14 +1,14 @@
-<!-- wp:core/text {"align":"right"} -->
+<!-- wp:text {"align":"right"} -->
 <p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
-<!-- /wp:core/text -->
+<!-- /wp:text -->
 
-<!-- wp:core/separator -->
-<hr class="wp-block-separator" />
-<!-- /wp:core/separator -->
+<!-- wp:separator -->
+<hr class="wp-block-separator">
+<!-- /wp:separator -->
 
-<!-- wp:core/freeform -->
+<!-- wp:freeform -->
 Testing freeform block with some
 <div class="wp-some-class">
 	HTML <span style="color: red;">content</span>
 </div>
-<!-- /wp:core/freeform -->
+<!-- /wp:freeform -->

--- a/test/fixtures/wp-gutenberg-post-no-mbstring.pegjs
+++ b/test/fixtures/wp-gutenberg-post-no-mbstring.pegjs
@@ -1,33 +1,205 @@
 {
 
+/*
+ *
+ *    _____       _             _
+ *   / ____|     | |           | |
+ *  | |  __ _   _| |_ ___ _ __ | |__   ___ _ __ __ _
+ *  | | |_ | | | | __/ _ \ '_ \| '_ \ / _ \ '__/ _` |
+ *  | |__| | |_| | ||  __/ | | | |_) |  __/ | | (_| |
+ *   \_____|\__,_|\__\___|_| |_|_.__/ \___|_|  \__, |
+ *                                              __/ |
+ *                  GRAMMAR                    |___/
+ *
+ *
+ * Welcome to the grammar file for Gutenberg posts!
+ *
+ * Please don't be distracted by the functions at the top
+ * here - they're just helpers for the grammar below. We
+ * try to keep them as minimal and simple as possible,
+ * but the parser generator forces us to declare them at
+ * the beginning of the file.
+ *
+ * What follows is the official specification grammar for
+ * documents created or edited in Gutenberg. It starts at
+ * the top-level rule `Block_List`
+ *
+ * The grammar is defined by a series of _rules_ and ways
+ * to return matches on those rules. It's a _PEG_, a
+ * parsing expression grammar, which simply means that for
+ * each of our rules we have a set of sub-rules to match
+ * on and the generated parser will try them in order
+ * until it finds the first match.
+ *
+ * This grammar is a _specification_ (with as little actual
+ * code as we can get away with) which is used by the
+ * parser generator to generate the actual _parser_ which
+ * is used by Gutenberg. We generate two parsers: one in
+ * JavaScript for use the browser and one in PHP for
+ * WordPress itself. PEG parser generators are available
+ * in many languages, though different libraries may require
+ * some translation of this grammar into their syntax.
+ *
+ * For more information:
+ * @see https://pegjs.org
+ * @see https://en.wikipedia.org/wiki/Parsing_expression_grammar
+ *
+ */
+
 /** <?php
 // The `maybeJSON` function is not needed in PHP because its return semantics
 // are the same as `json_decode`
+
+// array arguments are backwards because of PHP
+if ( ! function_exists( 'peg_array_partition' ) ) {
+    function peg_array_partition( $array, $predicate ) {
+        $truthy = array();
+        $falsey = array();
+
+        foreach ( $array as $item ) {
+            call_user_func( $predicate, $item )
+                ? $truthy[] = $item
+                : $falsey[] = $item;
+        }
+
+        return array( $truthy, $falsey );
+    }
+}
+
+if ( ! function_exists( 'peg_join_blocks' ) ) {
+    function peg_join_blocks( $pre, $tokens, $post ) {
+        $blocks = array();
+
+        if ( ! empty( $pre ) ) {
+            $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+        }
+
+        foreach ( $tokens as $token ) {
+            list( $token, $html ) = $token;
+
+            $blocks[] = $token;
+
+            if ( ! empty( $html ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+            }
+        }
+
+        if ( ! empty( $post ) ) {
+            $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+        }
+
+        return $blocks;
+    }
+}
+
 ?> **/
 
+function freeform( s ) {
+    return s.length && {
+        attrs: {},
+        innerHTML: s
+    };
+}
+
+function joinBlocks( pre, tokens, post ) {
+    var blocks = [], i, l, html, item, token;
+
+    if ( pre.length ) {
+        blocks.push( freeform( pre ) );
+    }
+
+    for ( i = 0, l = tokens.length; i < l; i++ ) {
+        item = tokens[ i ];
+        token = item[ 0 ];
+        html = item[ 1 ];
+
+        blocks.push( token );
+        if ( html.length ) {
+            blocks.push( freeform( html ) );
+        }
+    }
+
+    if ( post.length ) {
+        blocks.push( freeform( post ) );
+    }
+
+    return blocks;
+}
+
 function maybeJSON( s ) {
-	try {
-		return JSON.parse( s );
-	} catch (e) {
-		return null;
-	}
+    try {
+        return JSON.parse( s );
+    } catch (e) {
+        return null;
+    }
+}
+
+function partition( predicate, list ) {
+    var i, l, item;
+    var truthy = [];
+    var falsey = [];
+
+    // nod to performance over a simpler reduce
+    // and clone model we could have taken here
+    for ( i = 0, l = list.length; i < l; i++ ) {
+        item = list[ i ];
+
+        predicate( item )
+            ? truthy.push( item )
+            : falsey.push( item )
+    };
+
+    return [ truthy, falsey ];
 }
 
 }
 
-Document
-  = WP_Block_List
+//////////////////////////////////////////////////////
+//
+//   Here starts the grammar proper!
+//
+//////////////////////////////////////////////////////
 
-WP_Block_List
-  = WP_Block*
+Block_List
+  = pre:$(!Token .)*
+    ts:(t:Token html:$((!Token .)*) { /** <?php return array( $t, $html ); ?> **/ return [ t, html ] })*
+    post:$(.*)
+  { /** <?php return peg_join_blocks( $pre, $ts, $post ); ?> **/
+    return joinBlocks( pre, ts, post );
+  }
 
-WP_Block
-  = WP_Block_Void
-  / WP_Block_Balanced
-  / WP_Block_Html
+Token
+  = Tag_More
+  / Block_Void
+  / Block_Balanced
 
-WP_Block_Void
-  = "<!--" WS+ "wp:" blockName:WP_Block_Name WS+ attrs:(a:WP_Block_Attributes WS+ {
+Tag_More
+  = "<!--" WS* "more" customText:(WS+ text:$((!(WS* "-->") .)+) { /** <?php return $text; ?> **/ return text })? WS* "-->" noTeaser:(WS* "<!--noteaser-->")?
+  { /** <?php
+    $attrs = array( 'noTeaser' => (bool) $noTeaser );
+    if ( ! empty( $customText ) ) {
+      $attrs['customText'] = $customText;
+    }
+    return array(
+       'blockName' => 'core/more',
+       'attrs' => $attrs,
+       'innerHTML' => '',
+       'outerHTML' => $this->text(),
+    );
+    ?> **/
+    return {
+      blockName: 'core/more',
+      attrs: {
+        customText: customText || undefined,
+        noTeaser: !! noTeaser
+      },
+      innerHTML: '',
+      outerHTML: text()
+    }
+  }
+
+Block_Void
+  = "<!--" WS+ "wp:" blockName:Block_Name WS+ attrs:(a:Block_Attributes WS+ {
     /** <?php return $a; ?> **/
     return a;
   })? "/-->"
@@ -36,62 +208,51 @@ WP_Block_Void
     return array(
       'blockName'  => $blockName,
       'attrs'      => $attrs,
-      'rawContent' => '',
+      'innerBlocks' => array(),
+      'innerHTML' => '',
+      'outerHTML' => $this->text(),
     );
     ?> **/
 
     return {
       blockName: blockName,
       attrs: attrs,
-      rawContent: ''
+      innerBlocks: [],
+      innerHTML: '',
+      outerHTML: text()
     };
   }
 
-WP_Block_Balanced
-  = s:WP_Block_Start ts:(!WP_Block_End c:Any {
-    /** <?php return $c; ?> **/
-    return c;
-  })* e:WP_Block_End & {
-    /** <?php return $s['blockName'] === $e['blockName']; ?> **/
-    return s.blockName === e.blockName;
-  }
+Block_Balanced
+  = s:Block_Start children:(Token / $(!Block_End .))* e:Block_End
   {
     /** <?php
+    list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+
     return array(
       'blockName'  => $s['blockName'],
       'attrs'      => $s['attrs'],
-      'rawContent' => implode( '', $ts ),
+      'innerBlocks'  => $innerBlocks,
+      'innerHTML'  => implode( '', $innerHTML ),
+      'outerHTML' => $this->text(),
     );
     ?> **/
+
+    var innerContent = partition( function( a ) { return 'string' === typeof a }, children );
+    var innerHTML = innerContent[ 0 ];
+    var innerBlocks = innerContent[ 1 ];
 
     return {
       blockName: s.blockName,
       attrs: s.attrs,
-      rawContent: ts.join( '' )
+      innerBlocks: innerBlocks,
+      innerHTML: innerHTML.join( '' ),
+      outerHTML: text()
     };
   }
 
-WP_Block_Html
-  = ts:(!WP_Block_Balanced !WP_Block_Void c:Any {
-    /** <?php return $c; ?> **/
-    return c;
-  })+
-  {
-    /** <?php
-    return array(
-      'attrs'      => array(),
-      'rawContent' => implode( '', $ts ),
-    );
-    ?> **/
-
-    return {
-      attrs: {},
-      rawContent: ts.join( '' )
-    }
-  }
-
-WP_Block_Start
-  = "<!--" WS+ "wp:" blockName:WP_Block_Name WS+ attrs:(a:WP_Block_Attributes WS+ {
+Block_Start
+  = "<!--" WS+ "wp:" blockName:Block_Name WS+ attrs:(a:Block_Attributes WS+ {
     /** <?php return $a; ?> **/
     return a;
   })? "-->"
@@ -109,8 +270,8 @@ WP_Block_Start
     };
   }
 
-WP_Block_End
-  = "<!--" WS+ "/wp:" blockName:WP_Block_Name WS+ "-->"
+Block_End
+  = "<!--" WS+ "/wp:" blockName:Block_Name WS+ "-->"
   {
     /** <?php
     return array(
@@ -123,29 +284,29 @@ WP_Block_End
     };
   }
 
-WP_Block_Name
-  = $(ASCII_Letter (ASCII_AlphaNumeric / "/" ASCII_AlphaNumeric)*)
+Block_Name
+  = Namespaced_Block_Name
+  / Core_Block_Name
 
-WP_Block_Attributes
+Namespaced_Block_Name
+  = $( Block_Name_Part "/" Block_Name_Part )
+
+Core_Block_Name
+  = type:$( Block_Name_Part )
+  {
+    /** <?php return "core/$type"; ?> **/
+    return 'core/' + type;
+  }
+
+Block_Name_Part
+  = $( [a-z][a-z0-9_-]* )
+
+Block_Attributes
   = attrs:$("{" (!("}" WS+ """/"? "-->") .)* "}")
   {
     /** <?php return json_decode( $attrs, true ); ?> **/
     return maybeJSON( attrs );
   }
-
-ASCII_AlphaNumeric
-  = ASCII_Letter
-  / ASCII_Digit
-  / Special_Chars
-
-ASCII_Letter
-  = [a-zA-Z]
-
-ASCII_Digit
-  = [0-9]
-
-Special_Chars
-  = [\-\_]
 
 WS
   = [ \t\r\n]

--- a/test/fixtures/wp-gutenberg-post-no-mbstring.php
+++ b/test/fixtures/wp-gutenberg-post-no-mbstring.php
@@ -103,7 +103,7 @@ class Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {
@@ -259,29 +259,43 @@ class Parser {
     private $peg_c27;
     private $peg_c28;
     private $peg_c29;
+    private $peg_c30;
+    private $peg_c31;
 
-    private function peg_f0($blockName, $a) { return $a; }
-    private function peg_f1($blockName, $attrs) {
+    private function peg_f0($pre, $t, $html) { return array( $t, $html ); }
+    private function peg_f1($pre, $ts, $post) { return peg_join_blocks( $pre, $ts, $post ); }
+    private function peg_f2($text) { return $text; }
+    private function peg_f3($customText, $noTeaser) {
+        $attrs = array( 'noTeaser' => (bool) $noTeaser );
+        if ( ! empty( $customText ) ) {
+          $attrs['customText'] = $customText;
+        }
+        return array(
+           'blockName' => 'core/more',
+           'attrs' => $attrs,
+           'innerHTML' => '',
+           'outerHTML' => $this->text(),
+        );
+        }
+    private function peg_f4($blockName, $a) { return $a; }
+    private function peg_f5($blockName, $attrs) {
         return array(
           'blockName'  => $blockName,
           'attrs'      => $attrs,
-          'rawContent' => '',
+          'innerBlocks' => array(),
+          'innerHTML' => '',
+          'outerHTML' => $this->text(),
         );
         }
-    private function peg_f2($s, $c) { return $c; }
-    private function peg_f3($s, $ts, $e) { return $s['blockName'] === $e['blockName']; }
-    private function peg_f4($s, $ts, $e) {
+    private function peg_f6($s, $children, $e) {
+        list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+
         return array(
           'blockName'  => $s['blockName'],
           'attrs'      => $s['attrs'],
-          'rawContent' => implode( '', $ts ),
-        );
-        }
-    private function peg_f5($c) { return $c; }
-    private function peg_f6($ts) {
-        return array(
-          'attrs'      => array(),
-          'rawContent' => implode( '', $ts ),
+          'innerBlocks'  => $innerBlocks,
+          'innerHTML'  => implode( '', $innerHTML ),
+          'outerHTML' => $this->text(),
         );
         }
     private function peg_f7($blockName, $attrs) {
@@ -295,128 +309,572 @@ class Parser {
           'blockName' => $blockName,
         );
         }
-    private function peg_f9($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f9($type) { return "core/$type"; }
+    private function peg_f10($attrs) { return json_decode( $attrs, true ); }
 
-    private function peg_parseDocument() {
+    private function peg_parseBlock_List() {
 
-      $s0 = $this->peg_parseWP_Block_List();
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block_List() {
-
-      $s0 = array();
-      $s1 = $this->peg_parseWP_Block();
-      while ($s1 !== $this->peg_FAILED) {
-        $s0[] = $s1;
-        $s1 = $this->peg_parseWP_Block();
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = array();
+      $s3 = $this->peg_currPos;
+      $s4 = $this->peg_currPos;
+      $this->peg_silentFails++;
+      $s5 = $this->peg_parseToken();
+      $this->peg_silentFails--;
+      if ($s5 === $this->peg_FAILED) {
+        $s4 = null;
+      } else {
+        $this->peg_currPos = $s4;
+        $s4 = $this->peg_FAILED;
+      }
+      if ($s4 !== $this->peg_FAILED) {
+        if ($this->input_length > $this->peg_currPos) {
+          $s5 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s5 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c0);
+          }
+        }
+        if ($s5 !== $this->peg_FAILED) {
+          $s4 = array($s4, $s5);
+          $s3 = $s4;
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s3;
+        $s3 = $this->peg_FAILED;
+      }
+      while ($s3 !== $this->peg_FAILED) {
+        $s2[] = $s3;
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_currPos;
+        $this->peg_silentFails++;
+        $s5 = $this->peg_parseToken();
+        $this->peg_silentFails--;
+        if ($s5 === $this->peg_FAILED) {
+          $s4 = null;
+        } else {
+          $this->peg_currPos = $s4;
+          $s4 = $this->peg_FAILED;
+        }
+        if ($s4 !== $this->peg_FAILED) {
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $s4 = array($s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      }
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_parseToken();
+        if ($s4 !== $this->peg_FAILED) {
+          $s5 = $this->peg_currPos;
+          $s6 = array();
+          $s7 = $this->peg_currPos;
+          $s8 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          $s9 = $this->peg_parseToken();
+          $this->peg_silentFails--;
+          if ($s9 === $this->peg_FAILED) {
+            $s8 = null;
+          } else {
+            $this->peg_currPos = $s8;
+            $s8 = $this->peg_FAILED;
+          }
+          if ($s8 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s9 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s9 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s9 !== $this->peg_FAILED) {
+              $s8 = array($s8, $s9);
+              $s7 = $s8;
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s7;
+            $s7 = $this->peg_FAILED;
+          }
+          while ($s7 !== $this->peg_FAILED) {
+            $s6[] = $s7;
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          }
+          if ($s6 !== $this->peg_FAILED) {
+            $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+          } else {
+            $s5 = $s6;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s3;
+            $s4 = $this->peg_f0($s1, $s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_currPos;
+          $s4 = $this->peg_parseToken();
+          if ($s4 !== $this->peg_FAILED) {
+            $s5 = $this->peg_currPos;
+            $s6 = array();
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+            while ($s7 !== $this->peg_FAILED) {
+              $s6[] = $s7;
+              $s7 = $this->peg_currPos;
+              $s8 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s9 = $this->peg_parseToken();
+              $this->peg_silentFails--;
+              if ($s9 === $this->peg_FAILED) {
+                $s8 = null;
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s9 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s9 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s9 !== $this->peg_FAILED) {
+                  $s8 = array($s8, $s9);
+                  $s7 = $s8;
+                } else {
+                  $this->peg_currPos = $s7;
+                  $s7 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+            } else {
+              $s5 = $s6;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s3;
+              $s4 = $this->peg_f0($s1, $s4, $s5);
+              $s3 = $s4;
+            } else {
+              $this->peg_currPos = $s3;
+              $s3 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_currPos;
+          $s4 = array();
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          while ($s5 !== $this->peg_FAILED) {
+            $s4[] = $s5;
+            if ($this->input_length > $this->peg_currPos) {
+              $s5 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s5 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f1($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
 
       return $s0;
     }
 
-    private function peg_parseWP_Block() {
+    private function peg_parseToken() {
 
-      $s0 = $this->peg_parseWP_Block_Void();
+      $s0 = $this->peg_parseTag_More();
       if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseWP_Block_Balanced();
+        $s0 = $this->peg_parseBlock_Void();
         if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseWP_Block_Html();
+          $s0 = $this->peg_parseBlock_Balanced();
         }
       }
 
       return $s0;
     }
 
-    private function peg_parseWP_Block_Void() {
+    private function peg_parseTag_More() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
         $s3 = $this->peg_parseWS();
-        if ($s3 !== $this->peg_FAILED) {
-          while ($s3 !== $this->peg_FAILED) {
-            $s2[] = $s3;
-            $s3 = $this->peg_parseWS();
-          }
-        } else {
-          $s2 = $this->peg_FAILED;
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseWS();
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
-            $this->peg_currPos += 3;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c3) {
+            $s3 = $this->peg_c3;
+            $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c4);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_currPos;
+            $s5 = array();
+            $s6 = $this->peg_parseWS();
+            if ($s6 !== $this->peg_FAILED) {
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
+              }
+            } else {
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $s6 = $this->peg_currPos;
+              $s7 = array();
+              $s8 = $this->peg_currPos;
+              $s9 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s10 = $this->peg_currPos;
+              $s11 = array();
+              $s12 = $this->peg_parseWS();
+              while ($s12 !== $this->peg_FAILED) {
+                $s11[] = $s12;
+                $s12 = $this->peg_parseWS();
+              }
+              if ($s11 !== $this->peg_FAILED) {
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
+                  $this->peg_currPos += 3;
+                } else {
+                  $s12 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
+                }
+                if ($s12 !== $this->peg_FAILED) {
+                  $s11 = array($s11, $s12);
+                  $s10 = $s11;
+                } else {
+                  $this->peg_currPos = $s10;
+                  $s10 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s10;
+                $s10 = $this->peg_FAILED;
+              }
+              $this->peg_silentFails--;
+              if ($s10 === $this->peg_FAILED) {
+                $s9 = null;
+              } else {
+                $this->peg_currPos = $s9;
+                $s9 = $this->peg_FAILED;
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s10 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s10 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s10 !== $this->peg_FAILED) {
+                  $s9 = array($s9, $s10);
+                  $s8 = $s9;
+                } else {
+                  $this->peg_currPos = $s8;
+                  $s8 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                while ($s8 !== $this->peg_FAILED) {
+                  $s7[] = $s8;
+                  $s8 = $this->peg_currPos;
+                  $s9 = $this->peg_currPos;
+                  $this->peg_silentFails++;
+                  $s10 = $this->peg_currPos;
+                  $s11 = array();
+                  $s12 = $this->peg_parseWS();
+                  while ($s12 !== $this->peg_FAILED) {
+                    $s11[] = $s12;
+                    $s12 = $this->peg_parseWS();
+                  }
+                  if ($s11 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                      $s12 = $this->peg_c5;
+                      $this->peg_currPos += 3;
+                    } else {
+                      $s12 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c6);
+                      }
+                    }
+                    if ($s12 !== $this->peg_FAILED) {
+                      $s11 = array($s11, $s12);
+                      $s10 = $s11;
+                    } else {
+                      $this->peg_currPos = $s10;
+                      $s10 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s10;
+                    $s10 = $this->peg_FAILED;
+                  }
+                  $this->peg_silentFails--;
+                  if ($s10 === $this->peg_FAILED) {
+                    $s9 = null;
+                  } else {
+                    $this->peg_currPos = $s9;
+                    $s9 = $this->peg_FAILED;
+                  }
+                  if ($s9 !== $this->peg_FAILED) {
+                    if ($this->input_length > $this->peg_currPos) {
+                      $s10 = $this->input_substr($this->peg_currPos, 1);
+                      $this->peg_currPos++;
+                    } else {
+                      $s10 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c0);
+                      }
+                    }
+                    if ($s10 !== $this->peg_FAILED) {
+                      $s9 = array($s9, $s10);
+                      $s8 = $s9;
+                    } else {
+                      $this->peg_currPos = $s8;
+                      $s8 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s8;
+                    $s8 = $this->peg_FAILED;
+                  }
+                }
+              } else {
+                $s7 = $this->peg_FAILED;
+              }
+              if ($s7 !== $this->peg_FAILED) {
+                $s6 = $this->input_substr($s6, $this->peg_currPos - $s6);
+              } else {
+                $s6 = $s7;
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $this->peg_reportedPos = $s4;
+                $s5 = $this->peg_f2($s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+            if ($s4 === $this->peg_FAILED) {
+              $s4 = null;
+            }
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
-              if ($s6 !== $this->peg_FAILED) {
-                while ($s6 !== $this->peg_FAILED) {
-                  $s5[] = $s6;
-                  $s6 = $this->peg_parseWS();
-                }
-              } else {
-                $s5 = $this->peg_FAILED;
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
               }
               if ($s5 !== $this->peg_FAILED) {
-                $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
-                if ($s7 !== $this->peg_FAILED) {
-                  $s8 = array();
-                  $s9 = $this->peg_parseWS();
-                  if ($s9 !== $this->peg_FAILED) {
-                    while ($s9 !== $this->peg_FAILED) {
-                      $s8[] = $s9;
-                      $s9 = $this->peg_parseWS();
-                    }
-                  } else {
-                    $s8 = $this->peg_FAILED;
-                  }
-                  if ($s8 !== $this->peg_FAILED) {
-                    $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
-                    $s6 = $s7;
-                  } else {
-                    $this->peg_currPos = $s6;
-                    $s6 = $this->peg_FAILED;
-                  }
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
+                  $this->peg_currPos += 3;
                 } else {
-                  $this->peg_currPos = $s6;
                   $s6 = $this->peg_FAILED;
-                }
-                if ($s6 === $this->peg_FAILED) {
-                  $s6 = null;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c4) {
-                    $s7 = $this->peg_c4;
-                    $this->peg_currPos += 4;
-                  } else {
-                    $s7 = $this->peg_FAILED;
-                    if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c5);
+                  $s7 = $this->peg_currPos;
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  while ($s9 !== $this->peg_FAILED) {
+                    $s8[] = $s9;
+                    $s9 = $this->peg_parseWS();
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 15) === $this->peg_c7) {
+                      $s9 = $this->peg_c7;
+                      $this->peg_currPos += 15;
+                    } else {
+                      $s9 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c8);
+                      }
                     }
+                    if ($s9 !== $this->peg_FAILED) {
+                      $s8 = array($s8, $s9);
+                      $s7 = $s8;
+                    } else {
+                      $this->peg_currPos = $s7;
+                      $s7 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s7;
+                    $s7 = $this->peg_FAILED;
+                  }
+                  if ($s7 === $this->peg_FAILED) {
+                    $s7 = null;
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f1($s4, $s6);
+                    $s1 = $this->peg_f3($s4, $s7);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -450,79 +908,107 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Balanced() {
+    private function peg_parseBlock_Void() {
 
       $s0 = $this->peg_currPos;
-      $s1 = $this->peg_parseWP_Block_Start();
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
+        $this->peg_currPos += 4;
+      } else {
+        $s1 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c2);
+        }
+      }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
-        $s3 = $this->peg_currPos;
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_End();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s3;
-            $s4 = $this->peg_f2($s1, $s5);
-            $s3 = $s4;
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+        $s3 = $this->peg_parseWS();
+        if ($s3 !== $this->peg_FAILED) {
+          while ($s3 !== $this->peg_FAILED) {
+            $s2[] = $s3;
+            $s3 = $this->peg_parseWS();
           }
         } else {
-          $this->peg_currPos = $s3;
-          $s3 = $this->peg_FAILED;
-        }
-        while ($s3 !== $this->peg_FAILED) {
-          $s2[] = $s3;
-          $s3 = $this->peg_currPos;
-          $s4 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s5 = $this->peg_parseWP_Block_End();
-          $this->peg_silentFails--;
-          if ($s5 === $this->peg_FAILED) {
-            $s4 = null;
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
-          }
-          if ($s4 !== $this->peg_FAILED) {
-            $s5 = $this->peg_parseAny();
-            if ($s5 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s3;
-              $s4 = $this->peg_f2($s1, $s5);
-              $s3 = $s4;
-            } else {
-              $this->peg_currPos = $s3;
-              $s3 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
-          }
+          $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          $s3 = $this->peg_parseWP_Block_End();
-          if ($s3 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $this->peg_currPos;
-            $s4 = $this->peg_f3($s1, $s2, $s3);
-            if ($s4) {
-              $s4 = null;
-            } else {
-              $s4 = $this->peg_FAILED;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
+            $this->peg_currPos += 3;
+          } else {
+            $s3 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c10);
             }
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s0;
-              $s1 = $this->peg_f4($s1, $s2, $s3);
-              $s0 = $s1;
+              $s5 = array();
+              $s6 = $this->peg_parseWS();
+              if ($s6 !== $this->peg_FAILED) {
+                while ($s6 !== $this->peg_FAILED) {
+                  $s5[] = $s6;
+                  $s6 = $this->peg_parseWS();
+                }
+              } else {
+                $s5 = $this->peg_FAILED;
+              }
+              if ($s5 !== $this->peg_FAILED) {
+                $s6 = $this->peg_currPos;
+                $s7 = $this->peg_parseBlock_Attributes();
+                if ($s7 !== $this->peg_FAILED) {
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  if ($s9 !== $this->peg_FAILED) {
+                    while ($s9 !== $this->peg_FAILED) {
+                      $s8[] = $s9;
+                      $s9 = $this->peg_parseWS();
+                    }
+                  } else {
+                    $s8 = $this->peg_FAILED;
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s6;
+                    $s7 = $this->peg_f4($s4, $s7);
+                    $s6 = $s7;
+                  } else {
+                    $this->peg_currPos = $s6;
+                    $s6 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s6;
+                  $s6 = $this->peg_FAILED;
+                }
+                if ($s6 === $this->peg_FAILED) {
+                  $s6 = null;
+                }
+                if ($s6 !== $this->peg_FAILED) {
+                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c11) {
+                    $s7 = $this->peg_c11;
+                    $this->peg_currPos += 4;
+                  } else {
+                    $s7 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c12);
+                    }
+                  }
+                  if ($s7 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s0;
+                    $s1 = $this->peg_f5($s4, $s6);
+                    $s0 = $s1;
+                  } else {
+                    $this->peg_currPos = $s0;
+                    $s0 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s0;
+                  $s0 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s0;
+                $s0 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s0;
               $s0 = $this->peg_FAILED;
@@ -543,116 +1029,129 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Html() {
+    private function peg_parseBlock_Balanced() {
 
       $s0 = $this->peg_currPos;
-      $s1 = array();
-      $s2 = $this->peg_currPos;
-      $s3 = $this->peg_currPos;
-      $this->peg_silentFails++;
-      $s4 = $this->peg_parseWP_Block_Balanced();
-      $this->peg_silentFails--;
-      if ($s4 === $this->peg_FAILED) {
-        $s3 = null;
-      } else {
-        $this->peg_currPos = $s3;
-        $s3 = $this->peg_FAILED;
-      }
-      if ($s3 !== $this->peg_FAILED) {
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_Void();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s2;
-            $s3 = $this->peg_f5($s5);
-            $s2 = $s3;
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
-          }
-        } else {
-          $this->peg_currPos = $s2;
-          $s2 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s2;
-        $s2 = $this->peg_FAILED;
-      }
-      if ($s2 !== $this->peg_FAILED) {
-        while ($s2 !== $this->peg_FAILED) {
-          $s1[] = $s2;
-          $s2 = $this->peg_currPos;
+      $s1 = $this->peg_parseBlock_Start();
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_parseToken();
+        if ($s3 === $this->peg_FAILED) {
           $s3 = $this->peg_currPos;
+          $s4 = $this->peg_currPos;
+          $s5 = $this->peg_currPos;
           $this->peg_silentFails++;
-          $s4 = $this->peg_parseWP_Block_Balanced();
+          $s6 = $this->peg_parseBlock_End();
           $this->peg_silentFails--;
-          if ($s4 === $this->peg_FAILED) {
-            $s3 = null;
+          if ($s6 === $this->peg_FAILED) {
+            $s5 = null;
           } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
           }
-          if ($s3 !== $this->peg_FAILED) {
+          if ($s5 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s6 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s6 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = array($s5, $s6);
+              $s4 = $s5;
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseToken();
+          if ($s3 === $this->peg_FAILED) {
+            $s3 = $this->peg_currPos;
             $s4 = $this->peg_currPos;
+            $s5 = $this->peg_currPos;
             $this->peg_silentFails++;
-            $s5 = $this->peg_parseWP_Block_Void();
+            $s6 = $this->peg_parseBlock_End();
             $this->peg_silentFails--;
-            if ($s5 === $this->peg_FAILED) {
-              $s4 = null;
+            if ($s6 === $this->peg_FAILED) {
+              $s5 = null;
+            } else {
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s6 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s6 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $s5 = array($s5, $s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s4;
               $s4 = $this->peg_FAILED;
             }
             if ($s4 !== $this->peg_FAILED) {
-              $s5 = $this->peg_parseAny();
-              if ($s5 !== $this->peg_FAILED) {
-                $this->peg_reportedPos = $s2;
-                $s3 = $this->peg_f5($s5);
-                $s2 = $s3;
-              } else {
-                $this->peg_currPos = $s2;
-                $s2 = $this->peg_FAILED;
-              }
+              $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
             } else {
-              $this->peg_currPos = $s2;
-              $s2 = $this->peg_FAILED;
+              $s3 = $s4;
             }
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
           }
         }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_parseBlock_End();
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f6($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
       } else {
-        $s1 = $this->peg_FAILED;
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
-      if ($s1 !== $this->peg_FAILED) {
-        $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f6($s1);
-      }
-      $s0 = $s1;
 
       return $s0;
     }
 
-    private function peg_parseWP_Block_Start() {
+    private function peg_parseBlock_Start() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -667,17 +1166,17 @@ class Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
             $this->peg_currPos += 3;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c10);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -691,7 +1190,7 @@ class Parser {
               }
               if ($s5 !== $this->peg_FAILED) {
                 $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
+                $s7 = $this->peg_parseBlock_Attributes();
                 if ($s7 !== $this->peg_FAILED) {
                   $s8 = array();
                   $s9 = $this->peg_parseWS();
@@ -705,7 +1204,7 @@ class Parser {
                   }
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
+                    $s7 = $this->peg_f4($s4, $s7);
                     $s6 = $s7;
                   } else {
                     $this->peg_currPos = $s6;
@@ -719,13 +1218,13 @@ class Parser {
                   $s6 = null;
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s7 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s7 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s7 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s7 !== $this->peg_FAILED) {
@@ -764,16 +1263,16 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_End() {
+    private function peg_parseBlock_End() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -788,17 +1287,17 @@ class Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c8) {
-            $s3 = $this->peg_c8;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c13) {
+            $s3 = $this->peg_c13;
             $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c9);
+                $this->peg_fail($this->peg_c14);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -811,13 +1310,13 @@ class Parser {
                 $s5 = $this->peg_FAILED;
               }
               if ($s5 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s6 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s6 !== $this->peg_FAILED) {
@@ -852,65 +1351,109 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Name() {
+    private function peg_parseBlock_Name() {
+
+      $s0 = $this->peg_parseNamespaced_Block_Name();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_parseCore_Block_Name();
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseNamespaced_Block_Name() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
-      $s2 = $this->peg_parseASCII_Letter();
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+          $s3 = $this->peg_c15;
+          $this->peg_currPos++;
+        } else {
+          $s3 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c16);
+          }
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s4 = $this->peg_parseBlock_Name_Part();
+          if ($s4 !== $this->peg_FAILED) {
+            $s2 = array($s2, $s3, $s4);
+            $s1 = $s2;
+          } else {
+            $this->peg_currPos = $s1;
+            $s1 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s1;
+          $s1 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s1;
+        $s1 = $this->peg_FAILED;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+      } else {
+        $s0 = $s1;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseCore_Block_Name() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $s0;
+        $s1 = $this->peg_f9($s1);
+      }
+      $s0 = $s1;
+
+      return $s0;
+    }
+
+    private function peg_parseBlock_Name_Part() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      if (peg_char_class_test($this->peg_c17, $this->input_substr($this->peg_currPos, 1))) {
+        $s2 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s2 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c18);
+        }
+      }
       if ($s2 !== $this->peg_FAILED) {
         $s3 = array();
-        $s4 = $this->peg_parseASCII_AlphaNumeric();
-        if ($s4 === $this->peg_FAILED) {
-          $s4 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-            $s5 = $this->peg_c10;
-            $this->peg_currPos++;
-          } else {
-            $s5 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c11);
-            }
-          }
-          if ($s5 !== $this->peg_FAILED) {
-            $s6 = $this->peg_parseASCII_AlphaNumeric();
-            if ($s6 !== $this->peg_FAILED) {
-              $s5 = array($s5, $s6);
-              $s4 = $s5;
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
+        if (peg_char_class_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+          $s4 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s4 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c20);
           }
         }
         while ($s4 !== $this->peg_FAILED) {
           $s3[] = $s4;
-          $s4 = $this->peg_parseASCII_AlphaNumeric();
-          if ($s4 === $this->peg_FAILED) {
-            $s4 = $this->peg_currPos;
-            if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-              $s5 = $this->peg_c10;
-              $this->peg_currPos++;
-            } else {
-              $s5 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c11);
-              }
-            }
-            if ($s5 !== $this->peg_FAILED) {
-              $s6 = $this->peg_parseASCII_AlphaNumeric();
-              if ($s6 !== $this->peg_FAILED) {
-                $s5 = array($s5, $s6);
-                $s4 = $s5;
-              } else {
-                $this->peg_currPos = $s4;
-                $s4 = $this->peg_FAILED;
-              }
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
+          if (peg_char_class_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+            $s4 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s4 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c20);
             }
           }
         }
@@ -934,18 +1477,18 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Attributes() {
+    private function peg_parseBlock_Attributes() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c12) {
-        $s3 = $this->peg_c12;
+      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c21) {
+        $s3 = $this->peg_c21;
         $this->peg_currPos++;
       } else {
         $s3 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c13);
+            $this->peg_fail($this->peg_c22);
         }
       }
       if ($s3 !== $this->peg_FAILED) {
@@ -954,13 +1497,13 @@ class Parser {
         $s6 = $this->peg_currPos;
         $this->peg_silentFails++;
         $s7 = $this->peg_currPos;
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-          $s8 = $this->peg_c14;
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+          $s8 = $this->peg_c23;
           $this->peg_currPos++;
         } else {
           $s8 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c15);
+              $this->peg_fail($this->peg_c24);
           }
         }
         if ($s8 !== $this->peg_FAILED) {
@@ -975,28 +1518,28 @@ class Parser {
             $s9 = $this->peg_FAILED;
           }
           if ($s9 !== $this->peg_FAILED) {
-            $s10 = $this->peg_c16;
+            $s10 = $this->peg_c25;
             if ($s10 !== $this->peg_FAILED) {
-              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                $s11 = $this->peg_c10;
+              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                $s11 = $this->peg_c15;
                 $this->peg_currPos++;
               } else {
                 $s11 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c11);
+                    $this->peg_fail($this->peg_c16);
                 }
               }
               if ($s11 === $this->peg_FAILED) {
                 $s11 = null;
               }
               if ($s11 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s12 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s12 !== $this->peg_FAILED) {
@@ -1036,7 +1579,7 @@ class Parser {
           } else {
             $s7 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c17);
+                $this->peg_fail($this->peg_c0);
             }
           }
           if ($s7 !== $this->peg_FAILED) {
@@ -1056,13 +1599,13 @@ class Parser {
           $s6 = $this->peg_currPos;
           $this->peg_silentFails++;
           $s7 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s8 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s8 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s8 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s8 !== $this->peg_FAILED) {
@@ -1077,28 +1620,28 @@ class Parser {
               $s9 = $this->peg_FAILED;
             }
             if ($s9 !== $this->peg_FAILED) {
-              $s10 = $this->peg_c16;
+              $s10 = $this->peg_c25;
               if ($s10 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                  $s11 = $this->peg_c10;
+                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                  $s11 = $this->peg_c15;
                   $this->peg_currPos++;
                 } else {
                   $s11 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c11);
+                      $this->peg_fail($this->peg_c16);
                   }
                 }
                 if ($s11 === $this->peg_FAILED) {
                   $s11 = null;
                 }
                 if ($s11 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s12 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s12 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s12 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s12 !== $this->peg_FAILED) {
@@ -1138,7 +1681,7 @@ class Parser {
             } else {
               $s7 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c17);
+                  $this->peg_fail($this->peg_c0);
               }
             }
             if ($s7 !== $this->peg_FAILED) {
@@ -1154,13 +1697,13 @@ class Parser {
           }
         }
         if ($s4 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s5 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s5 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s5 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s5 !== $this->peg_FAILED) {
@@ -1185,87 +1728,14 @@ class Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f9($s1);
+        $s1 = $this->peg_f10($s1);
       }
       $s0 = $s1;
 
       return $s0;
     }
 
-    private function peg_parseASCII_AlphaNumeric() {
-
-      $s0 = $this->peg_parseASCII_Letter();
-      if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseASCII_Digit();
-        if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseSpecial_Chars();
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Letter() {
-
-      if (peg_char_class_test($this->peg_c18, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c19);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Digit() {
-
-      if (peg_char_class_test($this->peg_c20, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c21);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseSpecial_Chars() {
-
-      if (peg_char_class_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c23);
-        }
-      }
-
-      return $s0;
-    }
-
     private function peg_parseWS() {
-
-      if (peg_char_class_test($this->peg_c24, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c25);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseNewline() {
 
       if (peg_char_class_test($this->peg_c26, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1280,7 +1750,7 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parse_() {
+    private function peg_parseNewline() {
 
       if (peg_char_class_test($this->peg_c28, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1289,6 +1759,21 @@ class Parser {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
             $this->peg_fail($this->peg_c29);
+        }
+      }
+
+      return $s0;
+    }
+
+    private function peg_parse_() {
+
+      if (peg_char_class_test($this->peg_c30, $this->input_substr($this->peg_currPos, 1))) {
+        $s0 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s0 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c31);
         }
       }
 
@@ -1319,7 +1804,7 @@ class Parser {
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c17);
+            $this->peg_fail($this->peg_c0);
         }
       }
 
@@ -1340,39 +1825,41 @@ class Parser {
     $this->input_length = count($this->input);
 
     $this->peg_FAILED = new \stdClass;
-    $this->peg_c0 = "<!--";
-    $this->peg_c1 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
-    $this->peg_c2 = "wp:";
-    $this->peg_c3 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
-    $this->peg_c4 = "/-->";
-    $this->peg_c5 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
-    $this->peg_c6 = "-->";
-    $this->peg_c7 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
-    $this->peg_c8 = "/wp:";
-    $this->peg_c9 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
-    $this->peg_c10 = "/";
-    $this->peg_c11 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
-    $this->peg_c12 = "{";
-    $this->peg_c13 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
-    $this->peg_c14 = "}";
-    $this->peg_c15 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
-    $this->peg_c16 = "";
-    $this->peg_c17 = array("type" => "any", "description" => "any character" );
-    $this->peg_c18 = array(array(97,122), array(65,90));
-    $this->peg_c19 = array( "type" => "class", "value" => "[a-zA-Z]", "description" => "[a-zA-Z]" );
-    $this->peg_c20 = array(array(48,57));
-    $this->peg_c21 = array( "type" => "class", "value" => "[0-9]", "description" => "[0-9]" );
-    $this->peg_c22 = array(array(45,45), array(95,95));
-    $this->peg_c23 = array( "type" => "class", "value" => "[-_]", "description" => "[-_]" );
-    $this->peg_c24 = array(array(32,32), array(9,9), array(13,13), array(10,10));
-    $this->peg_c25 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
-    $this->peg_c26 = array(array(13,13), array(10,10));
-    $this->peg_c27 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
-    $this->peg_c28 = array(array(32,32), array(9,9));
-    $this->peg_c29 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
+    $this->peg_c0 = array("type" => "any", "description" => "any character" );
+    $this->peg_c1 = "<!--";
+    $this->peg_c2 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
+    $this->peg_c3 = "more";
+    $this->peg_c4 = array( "type" => "literal", "value" => "more", "description" => "\"more\"" );
+    $this->peg_c5 = "-->";
+    $this->peg_c6 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
+    $this->peg_c7 = "<!--noteaser-->";
+    $this->peg_c8 = array( "type" => "literal", "value" => "<!--noteaser-->", "description" => "\"<!--noteaser-->\"" );
+    $this->peg_c9 = "wp:";
+    $this->peg_c10 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
+    $this->peg_c11 = "/-->";
+    $this->peg_c12 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
+    $this->peg_c13 = "/wp:";
+    $this->peg_c14 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
+    $this->peg_c15 = "/";
+    $this->peg_c16 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
+    $this->peg_c17 = array(array(97,122));
+    $this->peg_c18 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
+    $this->peg_c19 = array(array(97,122), array(48,57), array(95,95), array(45,45));
+    $this->peg_c20 = array( "type" => "class", "value" => "[a-z0-9_-]", "description" => "[a-z0-9_-]" );
+    $this->peg_c21 = "{";
+    $this->peg_c22 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
+    $this->peg_c23 = "}";
+    $this->peg_c24 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
+    $this->peg_c25 = "";
+    $this->peg_c26 = array(array(32,32), array(9,9), array(13,13), array(10,10));
+    $this->peg_c27 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
+    $this->peg_c28 = array(array(13,13), array(10,10));
+    $this->peg_c29 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
+    $this->peg_c30 = array(array(32,32), array(9,9));
+    $this->peg_c31 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
 
-    $peg_startRuleFunctions = array( 'Document' => array($this, "peg_parseDocument") );
-    $peg_startRuleFunction  = array($this, "peg_parseDocument");
+    $peg_startRuleFunctions = array( 'Block_List' => array($this, "peg_parseBlock_List") );
+    $peg_startRuleFunction  = array($this, "peg_parseBlock_List");
     if (isset($options["startRule"])) {
       if (!(isset($peg_startRuleFunctions[$options["startRule"]]))) {
         throw new \Exception("Can't start parsing from rule \"" + $options["startRule"] + "\".");
@@ -1385,6 +1872,49 @@ class Parser {
 
     // The `maybeJSON` function is not needed in PHP because its return semantics
     // are the same as `json_decode`
+
+    // array arguments are backwards because of PHP
+    if ( ! function_exists( 'peg_array_partition' ) ) {
+        function peg_array_partition( $array, $predicate ) {
+            $truthy = array();
+            $falsey = array();
+
+            foreach ( $array as $item ) {
+                call_user_func( $predicate, $item )
+                    ? $truthy[] = $item
+                    : $falsey[] = $item;
+            }
+
+            return array( $truthy, $falsey );
+        }
+    }
+
+    if ( ! function_exists( 'peg_join_blocks' ) ) {
+        function peg_join_blocks( $pre, $tokens, $post ) {
+            $blocks = array();
+
+            if ( ! empty( $pre ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+            }
+
+            foreach ( $tokens as $token ) {
+                list( $token, $html ) = $token;
+
+                $blocks[] = $token;
+
+                if ( ! empty( $html ) ) {
+                    $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+                }
+            }
+
+            if ( ! empty( $post ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+            }
+
+            return $blocks;
+        }
+    }
+
 
     /* END initializer code */
 

--- a/test/fixtures/wp-gutenberg-post-no-mbstring.php52.php
+++ b/test/fixtures/wp-gutenberg-post-no-mbstring.php52.php
@@ -102,7 +102,7 @@ class php52_compat_Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {
@@ -258,29 +258,43 @@ class php52_compat_Parser {
     private $peg_c27;
     private $peg_c28;
     private $peg_c29;
+    private $peg_c30;
+    private $peg_c31;
 
-    private function peg_f0($blockName, $a) { return $a; }
-    private function peg_f1($blockName, $attrs) {
+    private function peg_f0($pre, $t, $html) { return array( $t, $html ); }
+    private function peg_f1($pre, $ts, $post) { return peg_join_blocks( $pre, $ts, $post ); }
+    private function peg_f2($text) { return $text; }
+    private function peg_f3($customText, $noTeaser) {
+        $attrs = array( 'noTeaser' => (bool) $noTeaser );
+        if ( ! empty( $customText ) ) {
+          $attrs['customText'] = $customText;
+        }
+        return array(
+           'blockName' => 'core/more',
+           'attrs' => $attrs,
+           'innerHTML' => '',
+           'outerHTML' => $this->text(),
+        );
+        }
+    private function peg_f4($blockName, $a) { return $a; }
+    private function peg_f5($blockName, $attrs) {
         return array(
           'blockName'  => $blockName,
           'attrs'      => $attrs,
-          'rawContent' => '',
+          'innerBlocks' => array(),
+          'innerHTML' => '',
+          'outerHTML' => $this->text(),
         );
         }
-    private function peg_f2($s, $c) { return $c; }
-    private function peg_f3($s, $ts, $e) { return $s['blockName'] === $e['blockName']; }
-    private function peg_f4($s, $ts, $e) {
+    private function peg_f6($s, $children, $e) {
+        list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+
         return array(
           'blockName'  => $s['blockName'],
           'attrs'      => $s['attrs'],
-          'rawContent' => implode( '', $ts ),
-        );
-        }
-    private function peg_f5($c) { return $c; }
-    private function peg_f6($ts) {
-        return array(
-          'attrs'      => array(),
-          'rawContent' => implode( '', $ts ),
+          'innerBlocks'  => $innerBlocks,
+          'innerHTML'  => implode( '', $innerHTML ),
+          'outerHTML' => $this->text(),
         );
         }
     private function peg_f7($blockName, $attrs) {
@@ -294,128 +308,572 @@ class php52_compat_Parser {
           'blockName' => $blockName,
         );
         }
-    private function peg_f9($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f9($type) { return "core/$type"; }
+    private function peg_f10($attrs) { return json_decode( $attrs, true ); }
 
-    private function peg_parseDocument() {
+    private function peg_parseBlock_List() {
 
-      $s0 = $this->peg_parseWP_Block_List();
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block_List() {
-
-      $s0 = array();
-      $s1 = $this->peg_parseWP_Block();
-      while ($s1 !== $this->peg_FAILED) {
-        $s0[] = $s1;
-        $s1 = $this->peg_parseWP_Block();
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = array();
+      $s3 = $this->peg_currPos;
+      $s4 = $this->peg_currPos;
+      $this->peg_silentFails++;
+      $s5 = $this->peg_parseToken();
+      $this->peg_silentFails--;
+      if ($s5 === $this->peg_FAILED) {
+        $s4 = null;
+      } else {
+        $this->peg_currPos = $s4;
+        $s4 = $this->peg_FAILED;
+      }
+      if ($s4 !== $this->peg_FAILED) {
+        if ($this->input_length > $this->peg_currPos) {
+          $s5 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s5 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c0);
+          }
+        }
+        if ($s5 !== $this->peg_FAILED) {
+          $s4 = array($s4, $s5);
+          $s3 = $s4;
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s3;
+        $s3 = $this->peg_FAILED;
+      }
+      while ($s3 !== $this->peg_FAILED) {
+        $s2[] = $s3;
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_currPos;
+        $this->peg_silentFails++;
+        $s5 = $this->peg_parseToken();
+        $this->peg_silentFails--;
+        if ($s5 === $this->peg_FAILED) {
+          $s4 = null;
+        } else {
+          $this->peg_currPos = $s4;
+          $s4 = $this->peg_FAILED;
+        }
+        if ($s4 !== $this->peg_FAILED) {
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $s4 = array($s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      }
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_parseToken();
+        if ($s4 !== $this->peg_FAILED) {
+          $s5 = $this->peg_currPos;
+          $s6 = array();
+          $s7 = $this->peg_currPos;
+          $s8 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          $s9 = $this->peg_parseToken();
+          $this->peg_silentFails--;
+          if ($s9 === $this->peg_FAILED) {
+            $s8 = null;
+          } else {
+            $this->peg_currPos = $s8;
+            $s8 = $this->peg_FAILED;
+          }
+          if ($s8 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s9 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s9 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s9 !== $this->peg_FAILED) {
+              $s8 = array($s8, $s9);
+              $s7 = $s8;
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s7;
+            $s7 = $this->peg_FAILED;
+          }
+          while ($s7 !== $this->peg_FAILED) {
+            $s6[] = $s7;
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          }
+          if ($s6 !== $this->peg_FAILED) {
+            $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+          } else {
+            $s5 = $s6;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s3;
+            $s4 = $this->peg_f0($s1, $s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_currPos;
+          $s4 = $this->peg_parseToken();
+          if ($s4 !== $this->peg_FAILED) {
+            $s5 = $this->peg_currPos;
+            $s6 = array();
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+            while ($s7 !== $this->peg_FAILED) {
+              $s6[] = $s7;
+              $s7 = $this->peg_currPos;
+              $s8 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s9 = $this->peg_parseToken();
+              $this->peg_silentFails--;
+              if ($s9 === $this->peg_FAILED) {
+                $s8 = null;
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s9 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s9 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s9 !== $this->peg_FAILED) {
+                  $s8 = array($s8, $s9);
+                  $s7 = $s8;
+                } else {
+                  $this->peg_currPos = $s7;
+                  $s7 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+            } else {
+              $s5 = $s6;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s3;
+              $s4 = $this->peg_f0($s1, $s4, $s5);
+              $s3 = $s4;
+            } else {
+              $this->peg_currPos = $s3;
+              $s3 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_currPos;
+          $s4 = array();
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          while ($s5 !== $this->peg_FAILED) {
+            $s4[] = $s5;
+            if ($this->input_length > $this->peg_currPos) {
+              $s5 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s5 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f1($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
 
       return $s0;
     }
 
-    private function peg_parseWP_Block() {
+    private function peg_parseToken() {
 
-      $s0 = $this->peg_parseWP_Block_Void();
+      $s0 = $this->peg_parseTag_More();
       if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseWP_Block_Balanced();
+        $s0 = $this->peg_parseBlock_Void();
         if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseWP_Block_Html();
+          $s0 = $this->peg_parseBlock_Balanced();
         }
       }
 
       return $s0;
     }
 
-    private function peg_parseWP_Block_Void() {
+    private function peg_parseTag_More() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
         $s3 = $this->peg_parseWS();
-        if ($s3 !== $this->peg_FAILED) {
-          while ($s3 !== $this->peg_FAILED) {
-            $s2[] = $s3;
-            $s3 = $this->peg_parseWS();
-          }
-        } else {
-          $s2 = $this->peg_FAILED;
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseWS();
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
-            $this->peg_currPos += 3;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c3) {
+            $s3 = $this->peg_c3;
+            $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c4);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_currPos;
+            $s5 = array();
+            $s6 = $this->peg_parseWS();
+            if ($s6 !== $this->peg_FAILED) {
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
+              }
+            } else {
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $s6 = $this->peg_currPos;
+              $s7 = array();
+              $s8 = $this->peg_currPos;
+              $s9 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s10 = $this->peg_currPos;
+              $s11 = array();
+              $s12 = $this->peg_parseWS();
+              while ($s12 !== $this->peg_FAILED) {
+                $s11[] = $s12;
+                $s12 = $this->peg_parseWS();
+              }
+              if ($s11 !== $this->peg_FAILED) {
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
+                  $this->peg_currPos += 3;
+                } else {
+                  $s12 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
+                }
+                if ($s12 !== $this->peg_FAILED) {
+                  $s11 = array($s11, $s12);
+                  $s10 = $s11;
+                } else {
+                  $this->peg_currPos = $s10;
+                  $s10 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s10;
+                $s10 = $this->peg_FAILED;
+              }
+              $this->peg_silentFails--;
+              if ($s10 === $this->peg_FAILED) {
+                $s9 = null;
+              } else {
+                $this->peg_currPos = $s9;
+                $s9 = $this->peg_FAILED;
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s10 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s10 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s10 !== $this->peg_FAILED) {
+                  $s9 = array($s9, $s10);
+                  $s8 = $s9;
+                } else {
+                  $this->peg_currPos = $s8;
+                  $s8 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                while ($s8 !== $this->peg_FAILED) {
+                  $s7[] = $s8;
+                  $s8 = $this->peg_currPos;
+                  $s9 = $this->peg_currPos;
+                  $this->peg_silentFails++;
+                  $s10 = $this->peg_currPos;
+                  $s11 = array();
+                  $s12 = $this->peg_parseWS();
+                  while ($s12 !== $this->peg_FAILED) {
+                    $s11[] = $s12;
+                    $s12 = $this->peg_parseWS();
+                  }
+                  if ($s11 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                      $s12 = $this->peg_c5;
+                      $this->peg_currPos += 3;
+                    } else {
+                      $s12 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c6);
+                      }
+                    }
+                    if ($s12 !== $this->peg_FAILED) {
+                      $s11 = array($s11, $s12);
+                      $s10 = $s11;
+                    } else {
+                      $this->peg_currPos = $s10;
+                      $s10 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s10;
+                    $s10 = $this->peg_FAILED;
+                  }
+                  $this->peg_silentFails--;
+                  if ($s10 === $this->peg_FAILED) {
+                    $s9 = null;
+                  } else {
+                    $this->peg_currPos = $s9;
+                    $s9 = $this->peg_FAILED;
+                  }
+                  if ($s9 !== $this->peg_FAILED) {
+                    if ($this->input_length > $this->peg_currPos) {
+                      $s10 = $this->input_substr($this->peg_currPos, 1);
+                      $this->peg_currPos++;
+                    } else {
+                      $s10 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c0);
+                      }
+                    }
+                    if ($s10 !== $this->peg_FAILED) {
+                      $s9 = array($s9, $s10);
+                      $s8 = $s9;
+                    } else {
+                      $this->peg_currPos = $s8;
+                      $s8 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s8;
+                    $s8 = $this->peg_FAILED;
+                  }
+                }
+              } else {
+                $s7 = $this->peg_FAILED;
+              }
+              if ($s7 !== $this->peg_FAILED) {
+                $s6 = $this->input_substr($s6, $this->peg_currPos - $s6);
+              } else {
+                $s6 = $s7;
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $this->peg_reportedPos = $s4;
+                $s5 = $this->peg_f2($s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+            if ($s4 === $this->peg_FAILED) {
+              $s4 = null;
+            }
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
-              if ($s6 !== $this->peg_FAILED) {
-                while ($s6 !== $this->peg_FAILED) {
-                  $s5[] = $s6;
-                  $s6 = $this->peg_parseWS();
-                }
-              } else {
-                $s5 = $this->peg_FAILED;
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
               }
               if ($s5 !== $this->peg_FAILED) {
-                $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
-                if ($s7 !== $this->peg_FAILED) {
-                  $s8 = array();
-                  $s9 = $this->peg_parseWS();
-                  if ($s9 !== $this->peg_FAILED) {
-                    while ($s9 !== $this->peg_FAILED) {
-                      $s8[] = $s9;
-                      $s9 = $this->peg_parseWS();
-                    }
-                  } else {
-                    $s8 = $this->peg_FAILED;
-                  }
-                  if ($s8 !== $this->peg_FAILED) {
-                    $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
-                    $s6 = $s7;
-                  } else {
-                    $this->peg_currPos = $s6;
-                    $s6 = $this->peg_FAILED;
-                  }
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
+                  $this->peg_currPos += 3;
                 } else {
-                  $this->peg_currPos = $s6;
                   $s6 = $this->peg_FAILED;
-                }
-                if ($s6 === $this->peg_FAILED) {
-                  $s6 = null;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c4) {
-                    $s7 = $this->peg_c4;
-                    $this->peg_currPos += 4;
-                  } else {
-                    $s7 = $this->peg_FAILED;
-                    if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c5);
+                  $s7 = $this->peg_currPos;
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  while ($s9 !== $this->peg_FAILED) {
+                    $s8[] = $s9;
+                    $s9 = $this->peg_parseWS();
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 15) === $this->peg_c7) {
+                      $s9 = $this->peg_c7;
+                      $this->peg_currPos += 15;
+                    } else {
+                      $s9 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c8);
+                      }
                     }
+                    if ($s9 !== $this->peg_FAILED) {
+                      $s8 = array($s8, $s9);
+                      $s7 = $s8;
+                    } else {
+                      $this->peg_currPos = $s7;
+                      $s7 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s7;
+                    $s7 = $this->peg_FAILED;
+                  }
+                  if ($s7 === $this->peg_FAILED) {
+                    $s7 = null;
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f1($s4, $s6);
+                    $s1 = $this->peg_f3($s4, $s7);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -449,79 +907,107 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Balanced() {
+    private function peg_parseBlock_Void() {
 
       $s0 = $this->peg_currPos;
-      $s1 = $this->peg_parseWP_Block_Start();
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
+        $this->peg_currPos += 4;
+      } else {
+        $s1 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c2);
+        }
+      }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
-        $s3 = $this->peg_currPos;
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_End();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s3;
-            $s4 = $this->peg_f2($s1, $s5);
-            $s3 = $s4;
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+        $s3 = $this->peg_parseWS();
+        if ($s3 !== $this->peg_FAILED) {
+          while ($s3 !== $this->peg_FAILED) {
+            $s2[] = $s3;
+            $s3 = $this->peg_parseWS();
           }
         } else {
-          $this->peg_currPos = $s3;
-          $s3 = $this->peg_FAILED;
-        }
-        while ($s3 !== $this->peg_FAILED) {
-          $s2[] = $s3;
-          $s3 = $this->peg_currPos;
-          $s4 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s5 = $this->peg_parseWP_Block_End();
-          $this->peg_silentFails--;
-          if ($s5 === $this->peg_FAILED) {
-            $s4 = null;
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
-          }
-          if ($s4 !== $this->peg_FAILED) {
-            $s5 = $this->peg_parseAny();
-            if ($s5 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s3;
-              $s4 = $this->peg_f2($s1, $s5);
-              $s3 = $s4;
-            } else {
-              $this->peg_currPos = $s3;
-              $s3 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
-          }
+          $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          $s3 = $this->peg_parseWP_Block_End();
-          if ($s3 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $this->peg_currPos;
-            $s4 = $this->peg_f3($s1, $s2, $s3);
-            if ($s4) {
-              $s4 = null;
-            } else {
-              $s4 = $this->peg_FAILED;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
+            $this->peg_currPos += 3;
+          } else {
+            $s3 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c10);
             }
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s0;
-              $s1 = $this->peg_f4($s1, $s2, $s3);
-              $s0 = $s1;
+              $s5 = array();
+              $s6 = $this->peg_parseWS();
+              if ($s6 !== $this->peg_FAILED) {
+                while ($s6 !== $this->peg_FAILED) {
+                  $s5[] = $s6;
+                  $s6 = $this->peg_parseWS();
+                }
+              } else {
+                $s5 = $this->peg_FAILED;
+              }
+              if ($s5 !== $this->peg_FAILED) {
+                $s6 = $this->peg_currPos;
+                $s7 = $this->peg_parseBlock_Attributes();
+                if ($s7 !== $this->peg_FAILED) {
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  if ($s9 !== $this->peg_FAILED) {
+                    while ($s9 !== $this->peg_FAILED) {
+                      $s8[] = $s9;
+                      $s9 = $this->peg_parseWS();
+                    }
+                  } else {
+                    $s8 = $this->peg_FAILED;
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s6;
+                    $s7 = $this->peg_f4($s4, $s7);
+                    $s6 = $s7;
+                  } else {
+                    $this->peg_currPos = $s6;
+                    $s6 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s6;
+                  $s6 = $this->peg_FAILED;
+                }
+                if ($s6 === $this->peg_FAILED) {
+                  $s6 = null;
+                }
+                if ($s6 !== $this->peg_FAILED) {
+                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c11) {
+                    $s7 = $this->peg_c11;
+                    $this->peg_currPos += 4;
+                  } else {
+                    $s7 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c12);
+                    }
+                  }
+                  if ($s7 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s0;
+                    $s1 = $this->peg_f5($s4, $s6);
+                    $s0 = $s1;
+                  } else {
+                    $this->peg_currPos = $s0;
+                    $s0 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s0;
+                  $s0 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s0;
+                $s0 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s0;
               $s0 = $this->peg_FAILED;
@@ -542,116 +1028,129 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Html() {
+    private function peg_parseBlock_Balanced() {
 
       $s0 = $this->peg_currPos;
-      $s1 = array();
-      $s2 = $this->peg_currPos;
-      $s3 = $this->peg_currPos;
-      $this->peg_silentFails++;
-      $s4 = $this->peg_parseWP_Block_Balanced();
-      $this->peg_silentFails--;
-      if ($s4 === $this->peg_FAILED) {
-        $s3 = null;
-      } else {
-        $this->peg_currPos = $s3;
-        $s3 = $this->peg_FAILED;
-      }
-      if ($s3 !== $this->peg_FAILED) {
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_Void();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s2;
-            $s3 = $this->peg_f5($s5);
-            $s2 = $s3;
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
-          }
-        } else {
-          $this->peg_currPos = $s2;
-          $s2 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s2;
-        $s2 = $this->peg_FAILED;
-      }
-      if ($s2 !== $this->peg_FAILED) {
-        while ($s2 !== $this->peg_FAILED) {
-          $s1[] = $s2;
-          $s2 = $this->peg_currPos;
+      $s1 = $this->peg_parseBlock_Start();
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_parseToken();
+        if ($s3 === $this->peg_FAILED) {
           $s3 = $this->peg_currPos;
+          $s4 = $this->peg_currPos;
+          $s5 = $this->peg_currPos;
           $this->peg_silentFails++;
-          $s4 = $this->peg_parseWP_Block_Balanced();
+          $s6 = $this->peg_parseBlock_End();
           $this->peg_silentFails--;
-          if ($s4 === $this->peg_FAILED) {
-            $s3 = null;
+          if ($s6 === $this->peg_FAILED) {
+            $s5 = null;
           } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
           }
-          if ($s3 !== $this->peg_FAILED) {
+          if ($s5 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s6 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s6 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = array($s5, $s6);
+              $s4 = $s5;
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseToken();
+          if ($s3 === $this->peg_FAILED) {
+            $s3 = $this->peg_currPos;
             $s4 = $this->peg_currPos;
+            $s5 = $this->peg_currPos;
             $this->peg_silentFails++;
-            $s5 = $this->peg_parseWP_Block_Void();
+            $s6 = $this->peg_parseBlock_End();
             $this->peg_silentFails--;
-            if ($s5 === $this->peg_FAILED) {
-              $s4 = null;
+            if ($s6 === $this->peg_FAILED) {
+              $s5 = null;
+            } else {
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s6 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s6 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $s5 = array($s5, $s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s4;
               $s4 = $this->peg_FAILED;
             }
             if ($s4 !== $this->peg_FAILED) {
-              $s5 = $this->peg_parseAny();
-              if ($s5 !== $this->peg_FAILED) {
-                $this->peg_reportedPos = $s2;
-                $s3 = $this->peg_f5($s5);
-                $s2 = $s3;
-              } else {
-                $this->peg_currPos = $s2;
-                $s2 = $this->peg_FAILED;
-              }
+              $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
             } else {
-              $this->peg_currPos = $s2;
-              $s2 = $this->peg_FAILED;
+              $s3 = $s4;
             }
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
           }
         }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_parseBlock_End();
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f6($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
       } else {
-        $s1 = $this->peg_FAILED;
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
-      if ($s1 !== $this->peg_FAILED) {
-        $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f6($s1);
-      }
-      $s0 = $s1;
 
       return $s0;
     }
 
-    private function peg_parseWP_Block_Start() {
+    private function peg_parseBlock_Start() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -666,17 +1165,17 @@ class php52_compat_Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
             $this->peg_currPos += 3;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c10);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -690,7 +1189,7 @@ class php52_compat_Parser {
               }
               if ($s5 !== $this->peg_FAILED) {
                 $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
+                $s7 = $this->peg_parseBlock_Attributes();
                 if ($s7 !== $this->peg_FAILED) {
                   $s8 = array();
                   $s9 = $this->peg_parseWS();
@@ -704,7 +1203,7 @@ class php52_compat_Parser {
                   }
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
+                    $s7 = $this->peg_f4($s4, $s7);
                     $s6 = $s7;
                   } else {
                     $this->peg_currPos = $s6;
@@ -718,13 +1217,13 @@ class php52_compat_Parser {
                   $s6 = null;
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s7 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s7 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s7 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s7 !== $this->peg_FAILED) {
@@ -763,16 +1262,16 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_End() {
+    private function peg_parseBlock_End() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -787,17 +1286,17 @@ class php52_compat_Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c8) {
-            $s3 = $this->peg_c8;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c13) {
+            $s3 = $this->peg_c13;
             $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c9);
+                $this->peg_fail($this->peg_c14);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -810,13 +1309,13 @@ class php52_compat_Parser {
                 $s5 = $this->peg_FAILED;
               }
               if ($s5 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s6 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s6 !== $this->peg_FAILED) {
@@ -851,65 +1350,109 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Name() {
+    private function peg_parseBlock_Name() {
+
+      $s0 = $this->peg_parseNamespaced_Block_Name();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_parseCore_Block_Name();
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseNamespaced_Block_Name() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
-      $s2 = $this->peg_parseASCII_Letter();
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+          $s3 = $this->peg_c15;
+          $this->peg_currPos++;
+        } else {
+          $s3 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c16);
+          }
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s4 = $this->peg_parseBlock_Name_Part();
+          if ($s4 !== $this->peg_FAILED) {
+            $s2 = array($s2, $s3, $s4);
+            $s1 = $s2;
+          } else {
+            $this->peg_currPos = $s1;
+            $s1 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s1;
+          $s1 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s1;
+        $s1 = $this->peg_FAILED;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+      } else {
+        $s0 = $s1;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseCore_Block_Name() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $s0;
+        $s1 = $this->peg_f9($s1);
+      }
+      $s0 = $s1;
+
+      return $s0;
+    }
+
+    private function peg_parseBlock_Name_Part() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      if (php52_compat_peg_char_class_test($this->peg_c17, $this->input_substr($this->peg_currPos, 1))) {
+        $s2 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s2 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c18);
+        }
+      }
       if ($s2 !== $this->peg_FAILED) {
         $s3 = array();
-        $s4 = $this->peg_parseASCII_AlphaNumeric();
-        if ($s4 === $this->peg_FAILED) {
-          $s4 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-            $s5 = $this->peg_c10;
-            $this->peg_currPos++;
-          } else {
-            $s5 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c11);
-            }
-          }
-          if ($s5 !== $this->peg_FAILED) {
-            $s6 = $this->peg_parseASCII_AlphaNumeric();
-            if ($s6 !== $this->peg_FAILED) {
-              $s5 = array($s5, $s6);
-              $s4 = $s5;
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
+        if (php52_compat_peg_char_class_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+          $s4 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s4 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c20);
           }
         }
         while ($s4 !== $this->peg_FAILED) {
           $s3[] = $s4;
-          $s4 = $this->peg_parseASCII_AlphaNumeric();
-          if ($s4 === $this->peg_FAILED) {
-            $s4 = $this->peg_currPos;
-            if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-              $s5 = $this->peg_c10;
-              $this->peg_currPos++;
-            } else {
-              $s5 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c11);
-              }
-            }
-            if ($s5 !== $this->peg_FAILED) {
-              $s6 = $this->peg_parseASCII_AlphaNumeric();
-              if ($s6 !== $this->peg_FAILED) {
-                $s5 = array($s5, $s6);
-                $s4 = $s5;
-              } else {
-                $this->peg_currPos = $s4;
-                $s4 = $this->peg_FAILED;
-              }
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
+          if (php52_compat_peg_char_class_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+            $s4 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s4 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c20);
             }
           }
         }
@@ -933,18 +1476,18 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Attributes() {
+    private function peg_parseBlock_Attributes() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c12) {
-        $s3 = $this->peg_c12;
+      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c21) {
+        $s3 = $this->peg_c21;
         $this->peg_currPos++;
       } else {
         $s3 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c13);
+            $this->peg_fail($this->peg_c22);
         }
       }
       if ($s3 !== $this->peg_FAILED) {
@@ -953,13 +1496,13 @@ class php52_compat_Parser {
         $s6 = $this->peg_currPos;
         $this->peg_silentFails++;
         $s7 = $this->peg_currPos;
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-          $s8 = $this->peg_c14;
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+          $s8 = $this->peg_c23;
           $this->peg_currPos++;
         } else {
           $s8 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c15);
+              $this->peg_fail($this->peg_c24);
           }
         }
         if ($s8 !== $this->peg_FAILED) {
@@ -974,28 +1517,28 @@ class php52_compat_Parser {
             $s9 = $this->peg_FAILED;
           }
           if ($s9 !== $this->peg_FAILED) {
-            $s10 = $this->peg_c16;
+            $s10 = $this->peg_c25;
             if ($s10 !== $this->peg_FAILED) {
-              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                $s11 = $this->peg_c10;
+              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                $s11 = $this->peg_c15;
                 $this->peg_currPos++;
               } else {
                 $s11 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c11);
+                    $this->peg_fail($this->peg_c16);
                 }
               }
               if ($s11 === $this->peg_FAILED) {
                 $s11 = null;
               }
               if ($s11 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s12 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s12 !== $this->peg_FAILED) {
@@ -1035,7 +1578,7 @@ class php52_compat_Parser {
           } else {
             $s7 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c17);
+                $this->peg_fail($this->peg_c0);
             }
           }
           if ($s7 !== $this->peg_FAILED) {
@@ -1055,13 +1598,13 @@ class php52_compat_Parser {
           $s6 = $this->peg_currPos;
           $this->peg_silentFails++;
           $s7 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s8 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s8 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s8 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s8 !== $this->peg_FAILED) {
@@ -1076,28 +1619,28 @@ class php52_compat_Parser {
               $s9 = $this->peg_FAILED;
             }
             if ($s9 !== $this->peg_FAILED) {
-              $s10 = $this->peg_c16;
+              $s10 = $this->peg_c25;
               if ($s10 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                  $s11 = $this->peg_c10;
+                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                  $s11 = $this->peg_c15;
                   $this->peg_currPos++;
                 } else {
                   $s11 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c11);
+                      $this->peg_fail($this->peg_c16);
                   }
                 }
                 if ($s11 === $this->peg_FAILED) {
                   $s11 = null;
                 }
                 if ($s11 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s12 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s12 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s12 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s12 !== $this->peg_FAILED) {
@@ -1137,7 +1680,7 @@ class php52_compat_Parser {
             } else {
               $s7 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c17);
+                  $this->peg_fail($this->peg_c0);
               }
             }
             if ($s7 !== $this->peg_FAILED) {
@@ -1153,13 +1696,13 @@ class php52_compat_Parser {
           }
         }
         if ($s4 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s5 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s5 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s5 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s5 !== $this->peg_FAILED) {
@@ -1184,87 +1727,14 @@ class php52_compat_Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f9($s1);
+        $s1 = $this->peg_f10($s1);
       }
       $s0 = $s1;
 
       return $s0;
     }
 
-    private function peg_parseASCII_AlphaNumeric() {
-
-      $s0 = $this->peg_parseASCII_Letter();
-      if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseASCII_Digit();
-        if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseSpecial_Chars();
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Letter() {
-
-      if (php52_compat_peg_char_class_test($this->peg_c18, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c19);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Digit() {
-
-      if (php52_compat_peg_char_class_test($this->peg_c20, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c21);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseSpecial_Chars() {
-
-      if (php52_compat_peg_char_class_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c23);
-        }
-      }
-
-      return $s0;
-    }
-
     private function peg_parseWS() {
-
-      if (php52_compat_peg_char_class_test($this->peg_c24, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c25);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseNewline() {
 
       if (php52_compat_peg_char_class_test($this->peg_c26, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1279,7 +1749,7 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parse_() {
+    private function peg_parseNewline() {
 
       if (php52_compat_peg_char_class_test($this->peg_c28, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1288,6 +1758,21 @@ class php52_compat_Parser {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
             $this->peg_fail($this->peg_c29);
+        }
+      }
+
+      return $s0;
+    }
+
+    private function peg_parse_() {
+
+      if (php52_compat_peg_char_class_test($this->peg_c30, $this->input_substr($this->peg_currPos, 1))) {
+        $s0 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s0 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c31);
         }
       }
 
@@ -1318,7 +1803,7 @@ class php52_compat_Parser {
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c17);
+            $this->peg_fail($this->peg_c0);
         }
       }
 
@@ -1339,39 +1824,41 @@ class php52_compat_Parser {
     $this->input_length = count($this->input);
 
     $this->peg_FAILED = new stdClass;
-    $this->peg_c0 = "<!--";
-    $this->peg_c1 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
-    $this->peg_c2 = "wp:";
-    $this->peg_c3 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
-    $this->peg_c4 = "/-->";
-    $this->peg_c5 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
-    $this->peg_c6 = "-->";
-    $this->peg_c7 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
-    $this->peg_c8 = "/wp:";
-    $this->peg_c9 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
-    $this->peg_c10 = "/";
-    $this->peg_c11 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
-    $this->peg_c12 = "{";
-    $this->peg_c13 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
-    $this->peg_c14 = "}";
-    $this->peg_c15 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
-    $this->peg_c16 = "";
-    $this->peg_c17 = array("type" => "any", "description" => "any character" );
-    $this->peg_c18 = array(array(97,122), array(65,90));
-    $this->peg_c19 = array( "type" => "class", "value" => "[a-zA-Z]", "description" => "[a-zA-Z]" );
-    $this->peg_c20 = array(array(48,57));
-    $this->peg_c21 = array( "type" => "class", "value" => "[0-9]", "description" => "[0-9]" );
-    $this->peg_c22 = array(array(45,45), array(95,95));
-    $this->peg_c23 = array( "type" => "class", "value" => "[-_]", "description" => "[-_]" );
-    $this->peg_c24 = array(array(32,32), array(9,9), array(13,13), array(10,10));
-    $this->peg_c25 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
-    $this->peg_c26 = array(array(13,13), array(10,10));
-    $this->peg_c27 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
-    $this->peg_c28 = array(array(32,32), array(9,9));
-    $this->peg_c29 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
+    $this->peg_c0 = array("type" => "any", "description" => "any character" );
+    $this->peg_c1 = "<!--";
+    $this->peg_c2 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
+    $this->peg_c3 = "more";
+    $this->peg_c4 = array( "type" => "literal", "value" => "more", "description" => "\"more\"" );
+    $this->peg_c5 = "-->";
+    $this->peg_c6 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
+    $this->peg_c7 = "<!--noteaser-->";
+    $this->peg_c8 = array( "type" => "literal", "value" => "<!--noteaser-->", "description" => "\"<!--noteaser-->\"" );
+    $this->peg_c9 = "wp:";
+    $this->peg_c10 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
+    $this->peg_c11 = "/-->";
+    $this->peg_c12 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
+    $this->peg_c13 = "/wp:";
+    $this->peg_c14 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
+    $this->peg_c15 = "/";
+    $this->peg_c16 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
+    $this->peg_c17 = array(array(97,122));
+    $this->peg_c18 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
+    $this->peg_c19 = array(array(97,122), array(48,57), array(95,95), array(45,45));
+    $this->peg_c20 = array( "type" => "class", "value" => "[a-z0-9_-]", "description" => "[a-z0-9_-]" );
+    $this->peg_c21 = "{";
+    $this->peg_c22 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
+    $this->peg_c23 = "}";
+    $this->peg_c24 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
+    $this->peg_c25 = "";
+    $this->peg_c26 = array(array(32,32), array(9,9), array(13,13), array(10,10));
+    $this->peg_c27 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
+    $this->peg_c28 = array(array(13,13), array(10,10));
+    $this->peg_c29 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
+    $this->peg_c30 = array(array(32,32), array(9,9));
+    $this->peg_c31 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
 
-    $peg_startRuleFunctions = array( 'Document' => array($this, "peg_parseDocument") );
-    $peg_startRuleFunction  = array($this, "peg_parseDocument");
+    $peg_startRuleFunctions = array( 'Block_List' => array($this, "peg_parseBlock_List") );
+    $peg_startRuleFunction  = array($this, "peg_parseBlock_List");
     if (isset($options["startRule"])) {
       if (!(isset($peg_startRuleFunctions[$options["startRule"]]))) {
         throw new Exception("Can't start parsing from rule \"" + $options["startRule"] + "\".");
@@ -1384,6 +1871,49 @@ class php52_compat_Parser {
 
     // The `maybeJSON` function is not needed in PHP because its return semantics
     // are the same as `json_decode`
+
+    // array arguments are backwards because of PHP
+    if ( ! function_exists( 'peg_array_partition' ) ) {
+        function peg_array_partition( $array, $predicate ) {
+            $truthy = array();
+            $falsey = array();
+
+            foreach ( $array as $item ) {
+                call_user_func( $predicate, $item )
+                    ? $truthy[] = $item
+                    : $falsey[] = $item;
+            }
+
+            return array( $truthy, $falsey );
+        }
+    }
+
+    if ( ! function_exists( 'peg_join_blocks' ) ) {
+        function peg_join_blocks( $pre, $tokens, $post ) {
+            $blocks = array();
+
+            if ( ! empty( $pre ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+            }
+
+            foreach ( $tokens as $token ) {
+                list( $token, $html ) = $token;
+
+                $blocks[] = $token;
+
+                if ( ! empty( $html ) ) {
+                    $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+                }
+            }
+
+            if ( ! empty( $post ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+            }
+
+            return $blocks;
+        }
+    }
+
 
     /* END initializer code */
 

--- a/test/fixtures/wp-gutenberg-post-no-mbstring/example-post.json
+++ b/test/fixtures/wp-gutenberg-post-no-mbstring/example-post.json
@@ -4,28 +4,34 @@
         "attrs": {
             "align": "right"
         },
-        "rawContent": "\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n",
+        "outerHTML": "<!-- wp:text {\"align\":\"right\"} -->\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n<!-- /wp:text -->"
     },
     {
         "attrs": [],
-        "rawContent": "\n\n"
+        "innerHTML": "\n\n"
     },
     {
         "blockName": "core/separator",
         "attrs": null,
-        "rawContent": "\n<hr class=\"wp-block-separator\" />\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<hr class=\"wp-block-separator\">\n",
+        "outerHTML": "<!-- wp:separator -->\n<hr class=\"wp-block-separator\">\n<!-- /wp:separator -->"
     },
     {
         "attrs": [],
-        "rawContent": "\n\n"
+        "innerHTML": "\n\n"
     },
     {
         "blockName": "core/freeform",
         "attrs": null,
-        "rawContent": "\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n"
+        "innerBlocks": [],
+        "innerHTML": "\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n",
+        "outerHTML": "<!-- wp:freeform -->\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n<!-- /wp:freeform -->"
     },
     {
         "attrs": [],
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/test/fixtures/wp-gutenberg-post-no-mbstring/example-post.txt
+++ b/test/fixtures/wp-gutenberg-post-no-mbstring/example-post.txt
@@ -1,14 +1,14 @@
-<!-- wp:core/text {"align":"right"} -->
+<!-- wp:text {"align":"right"} -->
 <p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
-<!-- /wp:core/text -->
+<!-- /wp:text -->
 
-<!-- wp:core/separator -->
-<hr class="wp-block-separator" />
-<!-- /wp:core/separator -->
+<!-- wp:separator -->
+<hr class="wp-block-separator">
+<!-- /wp:separator -->
 
-<!-- wp:core/freeform -->
+<!-- wp:freeform -->
 Testing freeform block with some
 <div class="wp-some-class">
 	HTML <span style="color: red;">content</span>
 </div>
-<!-- /wp:core/freeform -->
+<!-- /wp:freeform -->

--- a/test/fixtures/wp-gutenberg-post-with-errors.php
+++ b/test/fixtures/wp-gutenberg-post-with-errors.php
@@ -101,7 +101,7 @@ class Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {

--- a/test/fixtures/wp-gutenberg-post-with-errors.php52.php
+++ b/test/fixtures/wp-gutenberg-post-with-errors.php52.php
@@ -100,7 +100,7 @@ class php52_compat_Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {

--- a/test/fixtures/wp-gutenberg-post.pegjs
+++ b/test/fixtures/wp-gutenberg-post.pegjs
@@ -1,33 +1,205 @@
 {
 
+/*
+ *
+ *    _____       _             _
+ *   / ____|     | |           | |
+ *  | |  __ _   _| |_ ___ _ __ | |__   ___ _ __ __ _
+ *  | | |_ | | | | __/ _ \ '_ \| '_ \ / _ \ '__/ _` |
+ *  | |__| | |_| | ||  __/ | | | |_) |  __/ | | (_| |
+ *   \_____|\__,_|\__\___|_| |_|_.__/ \___|_|  \__, |
+ *                                              __/ |
+ *                  GRAMMAR                    |___/
+ *
+ *
+ * Welcome to the grammar file for Gutenberg posts!
+ *
+ * Please don't be distracted by the functions at the top
+ * here - they're just helpers for the grammar below. We
+ * try to keep them as minimal and simple as possible,
+ * but the parser generator forces us to declare them at
+ * the beginning of the file.
+ *
+ * What follows is the official specification grammar for
+ * documents created or edited in Gutenberg. It starts at
+ * the top-level rule `Block_List`
+ *
+ * The grammar is defined by a series of _rules_ and ways
+ * to return matches on those rules. It's a _PEG_, a
+ * parsing expression grammar, which simply means that for
+ * each of our rules we have a set of sub-rules to match
+ * on and the generated parser will try them in order
+ * until it finds the first match.
+ *
+ * This grammar is a _specification_ (with as little actual
+ * code as we can get away with) which is used by the
+ * parser generator to generate the actual _parser_ which
+ * is used by Gutenberg. We generate two parsers: one in
+ * JavaScript for use the browser and one in PHP for
+ * WordPress itself. PEG parser generators are available
+ * in many languages, though different libraries may require
+ * some translation of this grammar into their syntax.
+ *
+ * For more information:
+ * @see https://pegjs.org
+ * @see https://en.wikipedia.org/wiki/Parsing_expression_grammar
+ *
+ */
+
 /** <?php
 // The `maybeJSON` function is not needed in PHP because its return semantics
 // are the same as `json_decode`
+
+// array arguments are backwards because of PHP
+if ( ! function_exists( 'peg_array_partition' ) ) {
+    function peg_array_partition( $array, $predicate ) {
+        $truthy = array();
+        $falsey = array();
+
+        foreach ( $array as $item ) {
+            call_user_func( $predicate, $item )
+                ? $truthy[] = $item
+                : $falsey[] = $item;
+        }
+
+        return array( $truthy, $falsey );
+    }
+}
+
+if ( ! function_exists( 'peg_join_blocks' ) ) {
+    function peg_join_blocks( $pre, $tokens, $post ) {
+        $blocks = array();
+
+        if ( ! empty( $pre ) ) {
+            $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+        }
+
+        foreach ( $tokens as $token ) {
+            list( $token, $html ) = $token;
+
+            $blocks[] = $token;
+
+            if ( ! empty( $html ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+            }
+        }
+
+        if ( ! empty( $post ) ) {
+            $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+        }
+
+        return $blocks;
+    }
+}
+
 ?> **/
 
+function freeform( s ) {
+    return s.length && {
+        attrs: {},
+        innerHTML: s
+    };
+}
+
+function joinBlocks( pre, tokens, post ) {
+    var blocks = [], i, l, html, item, token;
+
+    if ( pre.length ) {
+        blocks.push( freeform( pre ) );
+    }
+
+    for ( i = 0, l = tokens.length; i < l; i++ ) {
+        item = tokens[ i ];
+        token = item[ 0 ];
+        html = item[ 1 ];
+
+        blocks.push( token );
+        if ( html.length ) {
+            blocks.push( freeform( html ) );
+        }
+    }
+
+    if ( post.length ) {
+        blocks.push( freeform( post ) );
+    }
+
+    return blocks;
+}
+
 function maybeJSON( s ) {
-	try {
-		return JSON.parse( s );
-	} catch (e) {
-		return null;
-	}
+    try {
+        return JSON.parse( s );
+    } catch (e) {
+        return null;
+    }
+}
+
+function partition( predicate, list ) {
+    var i, l, item;
+    var truthy = [];
+    var falsey = [];
+
+    // nod to performance over a simpler reduce
+    // and clone model we could have taken here
+    for ( i = 0, l = list.length; i < l; i++ ) {
+        item = list[ i ];
+
+        predicate( item )
+            ? truthy.push( item )
+            : falsey.push( item )
+    };
+
+    return [ truthy, falsey ];
 }
 
 }
 
-Document
-  = WP_Block_List
+//////////////////////////////////////////////////////
+//
+//   Here starts the grammar proper!
+//
+//////////////////////////////////////////////////////
 
-WP_Block_List
-  = WP_Block*
+Block_List
+  = pre:$(!Token .)*
+    ts:(t:Token html:$((!Token .)*) { /** <?php return array( $t, $html ); ?> **/ return [ t, html ] })*
+    post:$(.*)
+  { /** <?php return peg_join_blocks( $pre, $ts, $post ); ?> **/
+    return joinBlocks( pre, ts, post );
+  }
 
-WP_Block
-  = WP_Block_Void
-  / WP_Block_Balanced
-  / WP_Block_Html
+Token
+  = Tag_More
+  / Block_Void
+  / Block_Balanced
 
-WP_Block_Void
-  = "<!--" WS+ "wp:" blockName:WP_Block_Name WS+ attrs:(a:WP_Block_Attributes WS+ {
+Tag_More
+  = "<!--" WS* "more" customText:(WS+ text:$((!(WS* "-->") .)+) { /** <?php return $text; ?> **/ return text })? WS* "-->" noTeaser:(WS* "<!--noteaser-->")?
+  { /** <?php
+    $attrs = array( 'noTeaser' => (bool) $noTeaser );
+    if ( ! empty( $customText ) ) {
+      $attrs['customText'] = $customText;
+    }
+    return array(
+       'blockName' => 'core/more',
+       'attrs' => $attrs,
+       'innerHTML' => '',
+       'outerHTML' => $this->text(),
+    );
+    ?> **/
+    return {
+      blockName: 'core/more',
+      attrs: {
+        customText: customText || undefined,
+        noTeaser: !! noTeaser
+      },
+      innerHTML: '',
+      outerHTML: text()
+    }
+  }
+
+Block_Void
+  = "<!--" WS+ "wp:" blockName:Block_Name WS+ attrs:(a:Block_Attributes WS+ {
     /** <?php return $a; ?> **/
     return a;
   })? "/-->"
@@ -36,62 +208,51 @@ WP_Block_Void
     return array(
       'blockName'  => $blockName,
       'attrs'      => $attrs,
-      'rawContent' => '',
+      'innerBlocks' => array(),
+      'innerHTML' => '',
+      'outerHTML' => $this->text(),
     );
     ?> **/
 
     return {
       blockName: blockName,
       attrs: attrs,
-      rawContent: ''
+      innerBlocks: [],
+      innerHTML: '',
+      outerHTML: text()
     };
   }
 
-WP_Block_Balanced
-  = s:WP_Block_Start ts:(!WP_Block_End c:Any {
-    /** <?php return $c; ?> **/
-    return c;
-  })* e:WP_Block_End & {
-    /** <?php return $s['blockName'] === $e['blockName']; ?> **/
-    return s.blockName === e.blockName;
-  }
+Block_Balanced
+  = s:Block_Start children:(Token / $(!Block_End .))* e:Block_End
   {
     /** <?php
+    list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+
     return array(
       'blockName'  => $s['blockName'],
       'attrs'      => $s['attrs'],
-      'rawContent' => implode( '', $ts ),
+      'innerBlocks'  => $innerBlocks,
+      'innerHTML'  => implode( '', $innerHTML ),
+      'outerHTML' => $this->text(),
     );
     ?> **/
+
+    var innerContent = partition( function( a ) { return 'string' === typeof a }, children );
+    var innerHTML = innerContent[ 0 ];
+    var innerBlocks = innerContent[ 1 ];
 
     return {
       blockName: s.blockName,
       attrs: s.attrs,
-      rawContent: ts.join( '' )
+      innerBlocks: innerBlocks,
+      innerHTML: innerHTML.join( '' ),
+      outerHTML: text()
     };
   }
 
-WP_Block_Html
-  = ts:(!WP_Block_Balanced !WP_Block_Void c:Any {
-    /** <?php return $c; ?> **/
-    return c;
-  })+
-  {
-    /** <?php
-    return array(
-      'attrs'      => array(),
-      'rawContent' => implode( '', $ts ),
-    );
-    ?> **/
-
-    return {
-      attrs: {},
-      rawContent: ts.join( '' )
-    }
-  }
-
-WP_Block_Start
-  = "<!--" WS+ "wp:" blockName:WP_Block_Name WS+ attrs:(a:WP_Block_Attributes WS+ {
+Block_Start
+  = "<!--" WS+ "wp:" blockName:Block_Name WS+ attrs:(a:Block_Attributes WS+ {
     /** <?php return $a; ?> **/
     return a;
   })? "-->"
@@ -109,8 +270,8 @@ WP_Block_Start
     };
   }
 
-WP_Block_End
-  = "<!--" WS+ "/wp:" blockName:WP_Block_Name WS+ "-->"
+Block_End
+  = "<!--" WS+ "/wp:" blockName:Block_Name WS+ "-->"
   {
     /** <?php
     return array(
@@ -123,29 +284,29 @@ WP_Block_End
     };
   }
 
-WP_Block_Name
-  = $(ASCII_Letter (ASCII_AlphaNumeric / "/" ASCII_AlphaNumeric)*)
+Block_Name
+  = Namespaced_Block_Name
+  / Core_Block_Name
 
-WP_Block_Attributes
+Namespaced_Block_Name
+  = $( Block_Name_Part "/" Block_Name_Part )
+
+Core_Block_Name
+  = type:$( Block_Name_Part )
+  {
+    /** <?php return "core/$type"; ?> **/
+    return 'core/' + type;
+  }
+
+Block_Name_Part
+  = $( [a-z][a-z0-9_-]* )
+
+Block_Attributes
   = attrs:$("{" (!("}" WS+ """/"? "-->") .)* "}")
   {
     /** <?php return json_decode( $attrs, true ); ?> **/
     return maybeJSON( attrs );
   }
-
-ASCII_AlphaNumeric
-  = ASCII_Letter
-  / ASCII_Digit
-  / Special_Chars
-
-ASCII_Letter
-  = [a-zA-Z]
-
-ASCII_Digit
-  = [0-9]
-
-Special_Chars
-  = [\-\_]
 
 WS
   = [ \t\r\n]

--- a/test/fixtures/wp-gutenberg-post.php
+++ b/test/fixtures/wp-gutenberg-post.php
@@ -101,7 +101,7 @@ class Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {
@@ -257,29 +257,43 @@ class Parser {
     private $peg_c27;
     private $peg_c28;
     private $peg_c29;
+    private $peg_c30;
+    private $peg_c31;
 
-    private function peg_f0($blockName, $a) { return $a; }
-    private function peg_f1($blockName, $attrs) {
+    private function peg_f0($pre, $t, $html) { return array( $t, $html ); }
+    private function peg_f1($pre, $ts, $post) { return peg_join_blocks( $pre, $ts, $post ); }
+    private function peg_f2($text) { return $text; }
+    private function peg_f3($customText, $noTeaser) {
+        $attrs = array( 'noTeaser' => (bool) $noTeaser );
+        if ( ! empty( $customText ) ) {
+          $attrs['customText'] = $customText;
+        }
+        return array(
+           'blockName' => 'core/more',
+           'attrs' => $attrs,
+           'innerHTML' => '',
+           'outerHTML' => $this->text(),
+        );
+        }
+    private function peg_f4($blockName, $a) { return $a; }
+    private function peg_f5($blockName, $attrs) {
         return array(
           'blockName'  => $blockName,
           'attrs'      => $attrs,
-          'rawContent' => '',
+          'innerBlocks' => array(),
+          'innerHTML' => '',
+          'outerHTML' => $this->text(),
         );
         }
-    private function peg_f2($s, $c) { return $c; }
-    private function peg_f3($s, $ts, $e) { return $s['blockName'] === $e['blockName']; }
-    private function peg_f4($s, $ts, $e) {
+    private function peg_f6($s, $children, $e) {
+        list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+
         return array(
           'blockName'  => $s['blockName'],
           'attrs'      => $s['attrs'],
-          'rawContent' => implode( '', $ts ),
-        );
-        }
-    private function peg_f5($c) { return $c; }
-    private function peg_f6($ts) {
-        return array(
-          'attrs'      => array(),
-          'rawContent' => implode( '', $ts ),
+          'innerBlocks'  => $innerBlocks,
+          'innerHTML'  => implode( '', $innerHTML ),
+          'outerHTML' => $this->text(),
         );
         }
     private function peg_f7($blockName, $attrs) {
@@ -293,128 +307,572 @@ class Parser {
           'blockName' => $blockName,
         );
         }
-    private function peg_f9($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f9($type) { return "core/$type"; }
+    private function peg_f10($attrs) { return json_decode( $attrs, true ); }
 
-    private function peg_parseDocument() {
+    private function peg_parseBlock_List() {
 
-      $s0 = $this->peg_parseWP_Block_List();
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block_List() {
-
-      $s0 = array();
-      $s1 = $this->peg_parseWP_Block();
-      while ($s1 !== $this->peg_FAILED) {
-        $s0[] = $s1;
-        $s1 = $this->peg_parseWP_Block();
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = array();
+      $s3 = $this->peg_currPos;
+      $s4 = $this->peg_currPos;
+      $this->peg_silentFails++;
+      $s5 = $this->peg_parseToken();
+      $this->peg_silentFails--;
+      if ($s5 === $this->peg_FAILED) {
+        $s4 = null;
+      } else {
+        $this->peg_currPos = $s4;
+        $s4 = $this->peg_FAILED;
+      }
+      if ($s4 !== $this->peg_FAILED) {
+        if ($this->input_length > $this->peg_currPos) {
+          $s5 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s5 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c0);
+          }
+        }
+        if ($s5 !== $this->peg_FAILED) {
+          $s4 = array($s4, $s5);
+          $s3 = $s4;
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s3;
+        $s3 = $this->peg_FAILED;
+      }
+      while ($s3 !== $this->peg_FAILED) {
+        $s2[] = $s3;
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_currPos;
+        $this->peg_silentFails++;
+        $s5 = $this->peg_parseToken();
+        $this->peg_silentFails--;
+        if ($s5 === $this->peg_FAILED) {
+          $s4 = null;
+        } else {
+          $this->peg_currPos = $s4;
+          $s4 = $this->peg_FAILED;
+        }
+        if ($s4 !== $this->peg_FAILED) {
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $s4 = array($s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      }
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_parseToken();
+        if ($s4 !== $this->peg_FAILED) {
+          $s5 = $this->peg_currPos;
+          $s6 = array();
+          $s7 = $this->peg_currPos;
+          $s8 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          $s9 = $this->peg_parseToken();
+          $this->peg_silentFails--;
+          if ($s9 === $this->peg_FAILED) {
+            $s8 = null;
+          } else {
+            $this->peg_currPos = $s8;
+            $s8 = $this->peg_FAILED;
+          }
+          if ($s8 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s9 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s9 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s9 !== $this->peg_FAILED) {
+              $s8 = array($s8, $s9);
+              $s7 = $s8;
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s7;
+            $s7 = $this->peg_FAILED;
+          }
+          while ($s7 !== $this->peg_FAILED) {
+            $s6[] = $s7;
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          }
+          if ($s6 !== $this->peg_FAILED) {
+            $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+          } else {
+            $s5 = $s6;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s3;
+            $s4 = $this->peg_f0($s1, $s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_currPos;
+          $s4 = $this->peg_parseToken();
+          if ($s4 !== $this->peg_FAILED) {
+            $s5 = $this->peg_currPos;
+            $s6 = array();
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+            while ($s7 !== $this->peg_FAILED) {
+              $s6[] = $s7;
+              $s7 = $this->peg_currPos;
+              $s8 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s9 = $this->peg_parseToken();
+              $this->peg_silentFails--;
+              if ($s9 === $this->peg_FAILED) {
+                $s8 = null;
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s9 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s9 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s9 !== $this->peg_FAILED) {
+                  $s8 = array($s8, $s9);
+                  $s7 = $s8;
+                } else {
+                  $this->peg_currPos = $s7;
+                  $s7 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+            } else {
+              $s5 = $s6;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s3;
+              $s4 = $this->peg_f0($s1, $s4, $s5);
+              $s3 = $s4;
+            } else {
+              $this->peg_currPos = $s3;
+              $s3 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_currPos;
+          $s4 = array();
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          while ($s5 !== $this->peg_FAILED) {
+            $s4[] = $s5;
+            if ($this->input_length > $this->peg_currPos) {
+              $s5 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s5 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f1($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
 
       return $s0;
     }
 
-    private function peg_parseWP_Block() {
+    private function peg_parseToken() {
 
-      $s0 = $this->peg_parseWP_Block_Void();
+      $s0 = $this->peg_parseTag_More();
       if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseWP_Block_Balanced();
+        $s0 = $this->peg_parseBlock_Void();
         if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseWP_Block_Html();
+          $s0 = $this->peg_parseBlock_Balanced();
         }
       }
 
       return $s0;
     }
 
-    private function peg_parseWP_Block_Void() {
+    private function peg_parseTag_More() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
         $s3 = $this->peg_parseWS();
-        if ($s3 !== $this->peg_FAILED) {
-          while ($s3 !== $this->peg_FAILED) {
-            $s2[] = $s3;
-            $s3 = $this->peg_parseWS();
-          }
-        } else {
-          $s2 = $this->peg_FAILED;
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseWS();
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
-            $this->peg_currPos += 3;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c3) {
+            $s3 = $this->peg_c3;
+            $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c4);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_currPos;
+            $s5 = array();
+            $s6 = $this->peg_parseWS();
+            if ($s6 !== $this->peg_FAILED) {
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
+              }
+            } else {
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $s6 = $this->peg_currPos;
+              $s7 = array();
+              $s8 = $this->peg_currPos;
+              $s9 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s10 = $this->peg_currPos;
+              $s11 = array();
+              $s12 = $this->peg_parseWS();
+              while ($s12 !== $this->peg_FAILED) {
+                $s11[] = $s12;
+                $s12 = $this->peg_parseWS();
+              }
+              if ($s11 !== $this->peg_FAILED) {
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
+                  $this->peg_currPos += 3;
+                } else {
+                  $s12 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
+                }
+                if ($s12 !== $this->peg_FAILED) {
+                  $s11 = array($s11, $s12);
+                  $s10 = $s11;
+                } else {
+                  $this->peg_currPos = $s10;
+                  $s10 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s10;
+                $s10 = $this->peg_FAILED;
+              }
+              $this->peg_silentFails--;
+              if ($s10 === $this->peg_FAILED) {
+                $s9 = null;
+              } else {
+                $this->peg_currPos = $s9;
+                $s9 = $this->peg_FAILED;
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s10 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s10 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s10 !== $this->peg_FAILED) {
+                  $s9 = array($s9, $s10);
+                  $s8 = $s9;
+                } else {
+                  $this->peg_currPos = $s8;
+                  $s8 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                while ($s8 !== $this->peg_FAILED) {
+                  $s7[] = $s8;
+                  $s8 = $this->peg_currPos;
+                  $s9 = $this->peg_currPos;
+                  $this->peg_silentFails++;
+                  $s10 = $this->peg_currPos;
+                  $s11 = array();
+                  $s12 = $this->peg_parseWS();
+                  while ($s12 !== $this->peg_FAILED) {
+                    $s11[] = $s12;
+                    $s12 = $this->peg_parseWS();
+                  }
+                  if ($s11 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                      $s12 = $this->peg_c5;
+                      $this->peg_currPos += 3;
+                    } else {
+                      $s12 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c6);
+                      }
+                    }
+                    if ($s12 !== $this->peg_FAILED) {
+                      $s11 = array($s11, $s12);
+                      $s10 = $s11;
+                    } else {
+                      $this->peg_currPos = $s10;
+                      $s10 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s10;
+                    $s10 = $this->peg_FAILED;
+                  }
+                  $this->peg_silentFails--;
+                  if ($s10 === $this->peg_FAILED) {
+                    $s9 = null;
+                  } else {
+                    $this->peg_currPos = $s9;
+                    $s9 = $this->peg_FAILED;
+                  }
+                  if ($s9 !== $this->peg_FAILED) {
+                    if ($this->input_length > $this->peg_currPos) {
+                      $s10 = $this->input_substr($this->peg_currPos, 1);
+                      $this->peg_currPos++;
+                    } else {
+                      $s10 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c0);
+                      }
+                    }
+                    if ($s10 !== $this->peg_FAILED) {
+                      $s9 = array($s9, $s10);
+                      $s8 = $s9;
+                    } else {
+                      $this->peg_currPos = $s8;
+                      $s8 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s8;
+                    $s8 = $this->peg_FAILED;
+                  }
+                }
+              } else {
+                $s7 = $this->peg_FAILED;
+              }
+              if ($s7 !== $this->peg_FAILED) {
+                $s6 = $this->input_substr($s6, $this->peg_currPos - $s6);
+              } else {
+                $s6 = $s7;
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $this->peg_reportedPos = $s4;
+                $s5 = $this->peg_f2($s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+            if ($s4 === $this->peg_FAILED) {
+              $s4 = null;
+            }
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
-              if ($s6 !== $this->peg_FAILED) {
-                while ($s6 !== $this->peg_FAILED) {
-                  $s5[] = $s6;
-                  $s6 = $this->peg_parseWS();
-                }
-              } else {
-                $s5 = $this->peg_FAILED;
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
               }
               if ($s5 !== $this->peg_FAILED) {
-                $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
-                if ($s7 !== $this->peg_FAILED) {
-                  $s8 = array();
-                  $s9 = $this->peg_parseWS();
-                  if ($s9 !== $this->peg_FAILED) {
-                    while ($s9 !== $this->peg_FAILED) {
-                      $s8[] = $s9;
-                      $s9 = $this->peg_parseWS();
-                    }
-                  } else {
-                    $s8 = $this->peg_FAILED;
-                  }
-                  if ($s8 !== $this->peg_FAILED) {
-                    $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
-                    $s6 = $s7;
-                  } else {
-                    $this->peg_currPos = $s6;
-                    $s6 = $this->peg_FAILED;
-                  }
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
+                  $this->peg_currPos += 3;
                 } else {
-                  $this->peg_currPos = $s6;
                   $s6 = $this->peg_FAILED;
-                }
-                if ($s6 === $this->peg_FAILED) {
-                  $s6 = null;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c4) {
-                    $s7 = $this->peg_c4;
-                    $this->peg_currPos += 4;
-                  } else {
-                    $s7 = $this->peg_FAILED;
-                    if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c5);
+                  $s7 = $this->peg_currPos;
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  while ($s9 !== $this->peg_FAILED) {
+                    $s8[] = $s9;
+                    $s9 = $this->peg_parseWS();
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 15) === $this->peg_c7) {
+                      $s9 = $this->peg_c7;
+                      $this->peg_currPos += 15;
+                    } else {
+                      $s9 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c8);
+                      }
                     }
+                    if ($s9 !== $this->peg_FAILED) {
+                      $s8 = array($s8, $s9);
+                      $s7 = $s8;
+                    } else {
+                      $this->peg_currPos = $s7;
+                      $s7 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s7;
+                    $s7 = $this->peg_FAILED;
+                  }
+                  if ($s7 === $this->peg_FAILED) {
+                    $s7 = null;
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f1($s4, $s6);
+                    $s1 = $this->peg_f3($s4, $s7);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -448,79 +906,107 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Balanced() {
+    private function peg_parseBlock_Void() {
 
       $s0 = $this->peg_currPos;
-      $s1 = $this->peg_parseWP_Block_Start();
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
+        $this->peg_currPos += 4;
+      } else {
+        $s1 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c2);
+        }
+      }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
-        $s3 = $this->peg_currPos;
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_End();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s3;
-            $s4 = $this->peg_f2($s1, $s5);
-            $s3 = $s4;
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+        $s3 = $this->peg_parseWS();
+        if ($s3 !== $this->peg_FAILED) {
+          while ($s3 !== $this->peg_FAILED) {
+            $s2[] = $s3;
+            $s3 = $this->peg_parseWS();
           }
         } else {
-          $this->peg_currPos = $s3;
-          $s3 = $this->peg_FAILED;
-        }
-        while ($s3 !== $this->peg_FAILED) {
-          $s2[] = $s3;
-          $s3 = $this->peg_currPos;
-          $s4 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s5 = $this->peg_parseWP_Block_End();
-          $this->peg_silentFails--;
-          if ($s5 === $this->peg_FAILED) {
-            $s4 = null;
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
-          }
-          if ($s4 !== $this->peg_FAILED) {
-            $s5 = $this->peg_parseAny();
-            if ($s5 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s3;
-              $s4 = $this->peg_f2($s1, $s5);
-              $s3 = $s4;
-            } else {
-              $this->peg_currPos = $s3;
-              $s3 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
-          }
+          $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          $s3 = $this->peg_parseWP_Block_End();
-          if ($s3 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $this->peg_currPos;
-            $s4 = $this->peg_f3($s1, $s2, $s3);
-            if ($s4) {
-              $s4 = null;
-            } else {
-              $s4 = $this->peg_FAILED;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
+            $this->peg_currPos += 3;
+          } else {
+            $s3 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c10);
             }
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s0;
-              $s1 = $this->peg_f4($s1, $s2, $s3);
-              $s0 = $s1;
+              $s5 = array();
+              $s6 = $this->peg_parseWS();
+              if ($s6 !== $this->peg_FAILED) {
+                while ($s6 !== $this->peg_FAILED) {
+                  $s5[] = $s6;
+                  $s6 = $this->peg_parseWS();
+                }
+              } else {
+                $s5 = $this->peg_FAILED;
+              }
+              if ($s5 !== $this->peg_FAILED) {
+                $s6 = $this->peg_currPos;
+                $s7 = $this->peg_parseBlock_Attributes();
+                if ($s7 !== $this->peg_FAILED) {
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  if ($s9 !== $this->peg_FAILED) {
+                    while ($s9 !== $this->peg_FAILED) {
+                      $s8[] = $s9;
+                      $s9 = $this->peg_parseWS();
+                    }
+                  } else {
+                    $s8 = $this->peg_FAILED;
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s6;
+                    $s7 = $this->peg_f4($s4, $s7);
+                    $s6 = $s7;
+                  } else {
+                    $this->peg_currPos = $s6;
+                    $s6 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s6;
+                  $s6 = $this->peg_FAILED;
+                }
+                if ($s6 === $this->peg_FAILED) {
+                  $s6 = null;
+                }
+                if ($s6 !== $this->peg_FAILED) {
+                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c11) {
+                    $s7 = $this->peg_c11;
+                    $this->peg_currPos += 4;
+                  } else {
+                    $s7 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c12);
+                    }
+                  }
+                  if ($s7 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s0;
+                    $s1 = $this->peg_f5($s4, $s6);
+                    $s0 = $s1;
+                  } else {
+                    $this->peg_currPos = $s0;
+                    $s0 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s0;
+                  $s0 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s0;
+                $s0 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s0;
               $s0 = $this->peg_FAILED;
@@ -541,116 +1027,129 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Html() {
+    private function peg_parseBlock_Balanced() {
 
       $s0 = $this->peg_currPos;
-      $s1 = array();
-      $s2 = $this->peg_currPos;
-      $s3 = $this->peg_currPos;
-      $this->peg_silentFails++;
-      $s4 = $this->peg_parseWP_Block_Balanced();
-      $this->peg_silentFails--;
-      if ($s4 === $this->peg_FAILED) {
-        $s3 = null;
-      } else {
-        $this->peg_currPos = $s3;
-        $s3 = $this->peg_FAILED;
-      }
-      if ($s3 !== $this->peg_FAILED) {
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_Void();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s2;
-            $s3 = $this->peg_f5($s5);
-            $s2 = $s3;
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
-          }
-        } else {
-          $this->peg_currPos = $s2;
-          $s2 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s2;
-        $s2 = $this->peg_FAILED;
-      }
-      if ($s2 !== $this->peg_FAILED) {
-        while ($s2 !== $this->peg_FAILED) {
-          $s1[] = $s2;
-          $s2 = $this->peg_currPos;
+      $s1 = $this->peg_parseBlock_Start();
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_parseToken();
+        if ($s3 === $this->peg_FAILED) {
           $s3 = $this->peg_currPos;
+          $s4 = $this->peg_currPos;
+          $s5 = $this->peg_currPos;
           $this->peg_silentFails++;
-          $s4 = $this->peg_parseWP_Block_Balanced();
+          $s6 = $this->peg_parseBlock_End();
           $this->peg_silentFails--;
-          if ($s4 === $this->peg_FAILED) {
-            $s3 = null;
+          if ($s6 === $this->peg_FAILED) {
+            $s5 = null;
           } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
           }
-          if ($s3 !== $this->peg_FAILED) {
+          if ($s5 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s6 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s6 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = array($s5, $s6);
+              $s4 = $s5;
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseToken();
+          if ($s3 === $this->peg_FAILED) {
+            $s3 = $this->peg_currPos;
             $s4 = $this->peg_currPos;
+            $s5 = $this->peg_currPos;
             $this->peg_silentFails++;
-            $s5 = $this->peg_parseWP_Block_Void();
+            $s6 = $this->peg_parseBlock_End();
             $this->peg_silentFails--;
-            if ($s5 === $this->peg_FAILED) {
-              $s4 = null;
+            if ($s6 === $this->peg_FAILED) {
+              $s5 = null;
+            } else {
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s6 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s6 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $s5 = array($s5, $s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s4;
               $s4 = $this->peg_FAILED;
             }
             if ($s4 !== $this->peg_FAILED) {
-              $s5 = $this->peg_parseAny();
-              if ($s5 !== $this->peg_FAILED) {
-                $this->peg_reportedPos = $s2;
-                $s3 = $this->peg_f5($s5);
-                $s2 = $s3;
-              } else {
-                $this->peg_currPos = $s2;
-                $s2 = $this->peg_FAILED;
-              }
+              $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
             } else {
-              $this->peg_currPos = $s2;
-              $s2 = $this->peg_FAILED;
+              $s3 = $s4;
             }
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
           }
         }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_parseBlock_End();
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f6($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
       } else {
-        $s1 = $this->peg_FAILED;
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
-      if ($s1 !== $this->peg_FAILED) {
-        $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f6($s1);
-      }
-      $s0 = $s1;
 
       return $s0;
     }
 
-    private function peg_parseWP_Block_Start() {
+    private function peg_parseBlock_Start() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -665,17 +1164,17 @@ class Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
             $this->peg_currPos += 3;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c10);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -689,7 +1188,7 @@ class Parser {
               }
               if ($s5 !== $this->peg_FAILED) {
                 $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
+                $s7 = $this->peg_parseBlock_Attributes();
                 if ($s7 !== $this->peg_FAILED) {
                   $s8 = array();
                   $s9 = $this->peg_parseWS();
@@ -703,7 +1202,7 @@ class Parser {
                   }
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
+                    $s7 = $this->peg_f4($s4, $s7);
                     $s6 = $s7;
                   } else {
                     $this->peg_currPos = $s6;
@@ -717,13 +1216,13 @@ class Parser {
                   $s6 = null;
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s7 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s7 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s7 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s7 !== $this->peg_FAILED) {
@@ -762,16 +1261,16 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_End() {
+    private function peg_parseBlock_End() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -786,17 +1285,17 @@ class Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c8) {
-            $s3 = $this->peg_c8;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c13) {
+            $s3 = $this->peg_c13;
             $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c9);
+                $this->peg_fail($this->peg_c14);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -809,13 +1308,13 @@ class Parser {
                 $s5 = $this->peg_FAILED;
               }
               if ($s5 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s6 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s6 !== $this->peg_FAILED) {
@@ -850,65 +1349,109 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Name() {
+    private function peg_parseBlock_Name() {
+
+      $s0 = $this->peg_parseNamespaced_Block_Name();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_parseCore_Block_Name();
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseNamespaced_Block_Name() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
-      $s2 = $this->peg_parseASCII_Letter();
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+          $s3 = $this->peg_c15;
+          $this->peg_currPos++;
+        } else {
+          $s3 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c16);
+          }
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s4 = $this->peg_parseBlock_Name_Part();
+          if ($s4 !== $this->peg_FAILED) {
+            $s2 = array($s2, $s3, $s4);
+            $s1 = $s2;
+          } else {
+            $this->peg_currPos = $s1;
+            $s1 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s1;
+          $s1 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s1;
+        $s1 = $this->peg_FAILED;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+      } else {
+        $s0 = $s1;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseCore_Block_Name() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $s0;
+        $s1 = $this->peg_f9($s1);
+      }
+      $s0 = $s1;
+
+      return $s0;
+    }
+
+    private function peg_parseBlock_Name_Part() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      if (peg_regex_test($this->peg_c17, $this->input_substr($this->peg_currPos, 1))) {
+        $s2 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s2 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c18);
+        }
+      }
       if ($s2 !== $this->peg_FAILED) {
         $s3 = array();
-        $s4 = $this->peg_parseASCII_AlphaNumeric();
-        if ($s4 === $this->peg_FAILED) {
-          $s4 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-            $s5 = $this->peg_c10;
-            $this->peg_currPos++;
-          } else {
-            $s5 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c11);
-            }
-          }
-          if ($s5 !== $this->peg_FAILED) {
-            $s6 = $this->peg_parseASCII_AlphaNumeric();
-            if ($s6 !== $this->peg_FAILED) {
-              $s5 = array($s5, $s6);
-              $s4 = $s5;
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
+        if (peg_regex_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+          $s4 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s4 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c20);
           }
         }
         while ($s4 !== $this->peg_FAILED) {
           $s3[] = $s4;
-          $s4 = $this->peg_parseASCII_AlphaNumeric();
-          if ($s4 === $this->peg_FAILED) {
-            $s4 = $this->peg_currPos;
-            if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-              $s5 = $this->peg_c10;
-              $this->peg_currPos++;
-            } else {
-              $s5 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c11);
-              }
-            }
-            if ($s5 !== $this->peg_FAILED) {
-              $s6 = $this->peg_parseASCII_AlphaNumeric();
-              if ($s6 !== $this->peg_FAILED) {
-                $s5 = array($s5, $s6);
-                $s4 = $s5;
-              } else {
-                $this->peg_currPos = $s4;
-                $s4 = $this->peg_FAILED;
-              }
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
+          if (peg_regex_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+            $s4 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s4 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c20);
             }
           }
         }
@@ -932,18 +1475,18 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Attributes() {
+    private function peg_parseBlock_Attributes() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c12) {
-        $s3 = $this->peg_c12;
+      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c21) {
+        $s3 = $this->peg_c21;
         $this->peg_currPos++;
       } else {
         $s3 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c13);
+            $this->peg_fail($this->peg_c22);
         }
       }
       if ($s3 !== $this->peg_FAILED) {
@@ -952,13 +1495,13 @@ class Parser {
         $s6 = $this->peg_currPos;
         $this->peg_silentFails++;
         $s7 = $this->peg_currPos;
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-          $s8 = $this->peg_c14;
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+          $s8 = $this->peg_c23;
           $this->peg_currPos++;
         } else {
           $s8 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c15);
+              $this->peg_fail($this->peg_c24);
           }
         }
         if ($s8 !== $this->peg_FAILED) {
@@ -973,28 +1516,28 @@ class Parser {
             $s9 = $this->peg_FAILED;
           }
           if ($s9 !== $this->peg_FAILED) {
-            $s10 = $this->peg_c16;
+            $s10 = $this->peg_c25;
             if ($s10 !== $this->peg_FAILED) {
-              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                $s11 = $this->peg_c10;
+              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                $s11 = $this->peg_c15;
                 $this->peg_currPos++;
               } else {
                 $s11 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c11);
+                    $this->peg_fail($this->peg_c16);
                 }
               }
               if ($s11 === $this->peg_FAILED) {
                 $s11 = null;
               }
               if ($s11 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s12 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s12 !== $this->peg_FAILED) {
@@ -1034,7 +1577,7 @@ class Parser {
           } else {
             $s7 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c17);
+                $this->peg_fail($this->peg_c0);
             }
           }
           if ($s7 !== $this->peg_FAILED) {
@@ -1054,13 +1597,13 @@ class Parser {
           $s6 = $this->peg_currPos;
           $this->peg_silentFails++;
           $s7 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s8 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s8 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s8 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s8 !== $this->peg_FAILED) {
@@ -1075,28 +1618,28 @@ class Parser {
               $s9 = $this->peg_FAILED;
             }
             if ($s9 !== $this->peg_FAILED) {
-              $s10 = $this->peg_c16;
+              $s10 = $this->peg_c25;
               if ($s10 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                  $s11 = $this->peg_c10;
+                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                  $s11 = $this->peg_c15;
                   $this->peg_currPos++;
                 } else {
                   $s11 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c11);
+                      $this->peg_fail($this->peg_c16);
                   }
                 }
                 if ($s11 === $this->peg_FAILED) {
                   $s11 = null;
                 }
                 if ($s11 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s12 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s12 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s12 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s12 !== $this->peg_FAILED) {
@@ -1136,7 +1679,7 @@ class Parser {
             } else {
               $s7 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c17);
+                  $this->peg_fail($this->peg_c0);
               }
             }
             if ($s7 !== $this->peg_FAILED) {
@@ -1152,13 +1695,13 @@ class Parser {
           }
         }
         if ($s4 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s5 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s5 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s5 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s5 !== $this->peg_FAILED) {
@@ -1183,87 +1726,14 @@ class Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f9($s1);
+        $s1 = $this->peg_f10($s1);
       }
       $s0 = $s1;
 
       return $s0;
     }
 
-    private function peg_parseASCII_AlphaNumeric() {
-
-      $s0 = $this->peg_parseASCII_Letter();
-      if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseASCII_Digit();
-        if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseSpecial_Chars();
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Letter() {
-
-      if (peg_regex_test($this->peg_c18, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c19);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Digit() {
-
-      if (peg_regex_test($this->peg_c20, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c21);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseSpecial_Chars() {
-
-      if (peg_regex_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c23);
-        }
-      }
-
-      return $s0;
-    }
-
     private function peg_parseWS() {
-
-      if (peg_regex_test($this->peg_c24, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c25);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseNewline() {
 
       if (peg_regex_test($this->peg_c26, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1278,7 +1748,7 @@ class Parser {
       return $s0;
     }
 
-    private function peg_parse_() {
+    private function peg_parseNewline() {
 
       if (peg_regex_test($this->peg_c28, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1287,6 +1757,21 @@ class Parser {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
             $this->peg_fail($this->peg_c29);
+        }
+      }
+
+      return $s0;
+    }
+
+    private function peg_parse_() {
+
+      if (peg_regex_test($this->peg_c30, $this->input_substr($this->peg_currPos, 1))) {
+        $s0 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s0 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c31);
         }
       }
 
@@ -1317,7 +1802,7 @@ class Parser {
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c17);
+            $this->peg_fail($this->peg_c0);
         }
       }
 
@@ -1341,39 +1826,41 @@ class Parser {
     mb_regex_encoding("UTF-8");
 
     $this->peg_FAILED = new \stdClass;
-    $this->peg_c0 = "<!--";
-    $this->peg_c1 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
-    $this->peg_c2 = "wp:";
-    $this->peg_c3 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
-    $this->peg_c4 = "/-->";
-    $this->peg_c5 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
-    $this->peg_c6 = "-->";
-    $this->peg_c7 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
-    $this->peg_c8 = "/wp:";
-    $this->peg_c9 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
-    $this->peg_c10 = "/";
-    $this->peg_c11 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
-    $this->peg_c12 = "{";
-    $this->peg_c13 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
-    $this->peg_c14 = "}";
-    $this->peg_c15 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
-    $this->peg_c16 = "";
-    $this->peg_c17 = array("type" => "any", "description" => "any character" );
-    $this->peg_c18 = "/^[a-zA-Z]/";
-    $this->peg_c19 = array( "type" => "class", "value" => "[a-zA-Z]", "description" => "[a-zA-Z]" );
-    $this->peg_c20 = "/^[0-9]/";
-    $this->peg_c21 = array( "type" => "class", "value" => "[0-9]", "description" => "[0-9]" );
-    $this->peg_c22 = "/^[-_]/";
-    $this->peg_c23 = array( "type" => "class", "value" => "[-_]", "description" => "[-_]" );
-    $this->peg_c24 = "/^[ \\t\\r\\n]/";
-    $this->peg_c25 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
-    $this->peg_c26 = "/^[\\r\\n]/";
-    $this->peg_c27 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
-    $this->peg_c28 = "/^[ \\t]/";
-    $this->peg_c29 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
+    $this->peg_c0 = array("type" => "any", "description" => "any character" );
+    $this->peg_c1 = "<!--";
+    $this->peg_c2 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
+    $this->peg_c3 = "more";
+    $this->peg_c4 = array( "type" => "literal", "value" => "more", "description" => "\"more\"" );
+    $this->peg_c5 = "-->";
+    $this->peg_c6 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
+    $this->peg_c7 = "<!--noteaser-->";
+    $this->peg_c8 = array( "type" => "literal", "value" => "<!--noteaser-->", "description" => "\"<!--noteaser-->\"" );
+    $this->peg_c9 = "wp:";
+    $this->peg_c10 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
+    $this->peg_c11 = "/-->";
+    $this->peg_c12 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
+    $this->peg_c13 = "/wp:";
+    $this->peg_c14 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
+    $this->peg_c15 = "/";
+    $this->peg_c16 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
+    $this->peg_c17 = "/^[a-z]/";
+    $this->peg_c18 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
+    $this->peg_c19 = "/^[a-z0-9_-]/";
+    $this->peg_c20 = array( "type" => "class", "value" => "[a-z0-9_-]", "description" => "[a-z0-9_-]" );
+    $this->peg_c21 = "{";
+    $this->peg_c22 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
+    $this->peg_c23 = "}";
+    $this->peg_c24 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
+    $this->peg_c25 = "";
+    $this->peg_c26 = "/^[ \\t\\r\\n]/";
+    $this->peg_c27 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
+    $this->peg_c28 = "/^[\\r\\n]/";
+    $this->peg_c29 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
+    $this->peg_c30 = "/^[ \\t]/";
+    $this->peg_c31 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
 
-    $peg_startRuleFunctions = array( 'Document' => array($this, "peg_parseDocument") );
-    $peg_startRuleFunction  = array($this, "peg_parseDocument");
+    $peg_startRuleFunctions = array( 'Block_List' => array($this, "peg_parseBlock_List") );
+    $peg_startRuleFunction  = array($this, "peg_parseBlock_List");
     if (isset($options["startRule"])) {
       if (!(isset($peg_startRuleFunctions[$options["startRule"]]))) {
         throw new \Exception("Can't start parsing from rule \"" + $options["startRule"] + "\".");
@@ -1386,6 +1873,49 @@ class Parser {
 
     // The `maybeJSON` function is not needed in PHP because its return semantics
     // are the same as `json_decode`
+
+    // array arguments are backwards because of PHP
+    if ( ! function_exists( 'peg_array_partition' ) ) {
+        function peg_array_partition( $array, $predicate ) {
+            $truthy = array();
+            $falsey = array();
+
+            foreach ( $array as $item ) {
+                call_user_func( $predicate, $item )
+                    ? $truthy[] = $item
+                    : $falsey[] = $item;
+            }
+
+            return array( $truthy, $falsey );
+        }
+    }
+
+    if ( ! function_exists( 'peg_join_blocks' ) ) {
+        function peg_join_blocks( $pre, $tokens, $post ) {
+            $blocks = array();
+
+            if ( ! empty( $pre ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+            }
+
+            foreach ( $tokens as $token ) {
+                list( $token, $html ) = $token;
+
+                $blocks[] = $token;
+
+                if ( ! empty( $html ) ) {
+                    $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+                }
+            }
+
+            if ( ! empty( $post ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+            }
+
+            return $blocks;
+        }
+    }
+
 
     /* END initializer code */
 

--- a/test/fixtures/wp-gutenberg-post.php52.php
+++ b/test/fixtures/wp-gutenberg-post.php52.php
@@ -100,7 +100,7 @@ class php52_compat_Parser {
 
 
     private function text() {
-      return substr($this->input, $this->peg_reportedPos, $this->peg_reportedPos + $this->peg_currPos);
+      return $this->input_substr($this->peg_reportedPos, $this->peg_currPos - $this->peg_reportedPos);
     }
 
     private function offset() {
@@ -256,29 +256,43 @@ class php52_compat_Parser {
     private $peg_c27;
     private $peg_c28;
     private $peg_c29;
+    private $peg_c30;
+    private $peg_c31;
 
-    private function peg_f0($blockName, $a) { return $a; }
-    private function peg_f1($blockName, $attrs) {
+    private function peg_f0($pre, $t, $html) { return array( $t, $html ); }
+    private function peg_f1($pre, $ts, $post) { return peg_join_blocks( $pre, $ts, $post ); }
+    private function peg_f2($text) { return $text; }
+    private function peg_f3($customText, $noTeaser) {
+        $attrs = array( 'noTeaser' => (bool) $noTeaser );
+        if ( ! empty( $customText ) ) {
+          $attrs['customText'] = $customText;
+        }
+        return array(
+           'blockName' => 'core/more',
+           'attrs' => $attrs,
+           'innerHTML' => '',
+           'outerHTML' => $this->text(),
+        );
+        }
+    private function peg_f4($blockName, $a) { return $a; }
+    private function peg_f5($blockName, $attrs) {
         return array(
           'blockName'  => $blockName,
           'attrs'      => $attrs,
-          'rawContent' => '',
+          'innerBlocks' => array(),
+          'innerHTML' => '',
+          'outerHTML' => $this->text(),
         );
         }
-    private function peg_f2($s, $c) { return $c; }
-    private function peg_f3($s, $ts, $e) { return $s['blockName'] === $e['blockName']; }
-    private function peg_f4($s, $ts, $e) {
+    private function peg_f6($s, $children, $e) {
+        list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+
         return array(
           'blockName'  => $s['blockName'],
           'attrs'      => $s['attrs'],
-          'rawContent' => implode( '', $ts ),
-        );
-        }
-    private function peg_f5($c) { return $c; }
-    private function peg_f6($ts) {
-        return array(
-          'attrs'      => array(),
-          'rawContent' => implode( '', $ts ),
+          'innerBlocks'  => $innerBlocks,
+          'innerHTML'  => implode( '', $innerHTML ),
+          'outerHTML' => $this->text(),
         );
         }
     private function peg_f7($blockName, $attrs) {
@@ -292,128 +306,572 @@ class php52_compat_Parser {
           'blockName' => $blockName,
         );
         }
-    private function peg_f9($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f9($type) { return "core/$type"; }
+    private function peg_f10($attrs) { return json_decode( $attrs, true ); }
 
-    private function peg_parseDocument() {
+    private function peg_parseBlock_List() {
 
-      $s0 = $this->peg_parseWP_Block_List();
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block_List() {
-
-      $s0 = array();
-      $s1 = $this->peg_parseWP_Block();
-      while ($s1 !== $this->peg_FAILED) {
-        $s0[] = $s1;
-        $s1 = $this->peg_parseWP_Block();
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = array();
+      $s3 = $this->peg_currPos;
+      $s4 = $this->peg_currPos;
+      $this->peg_silentFails++;
+      $s5 = $this->peg_parseToken();
+      $this->peg_silentFails--;
+      if ($s5 === $this->peg_FAILED) {
+        $s4 = null;
+      } else {
+        $this->peg_currPos = $s4;
+        $s4 = $this->peg_FAILED;
+      }
+      if ($s4 !== $this->peg_FAILED) {
+        if ($this->input_length > $this->peg_currPos) {
+          $s5 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s5 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c0);
+          }
+        }
+        if ($s5 !== $this->peg_FAILED) {
+          $s4 = array($s4, $s5);
+          $s3 = $s4;
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s3;
+        $s3 = $this->peg_FAILED;
+      }
+      while ($s3 !== $this->peg_FAILED) {
+        $s2[] = $s3;
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_currPos;
+        $this->peg_silentFails++;
+        $s5 = $this->peg_parseToken();
+        $this->peg_silentFails--;
+        if ($s5 === $this->peg_FAILED) {
+          $s4 = null;
+        } else {
+          $this->peg_currPos = $s4;
+          $s4 = $this->peg_FAILED;
+        }
+        if ($s4 !== $this->peg_FAILED) {
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $s4 = array($s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      }
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_parseToken();
+        if ($s4 !== $this->peg_FAILED) {
+          $s5 = $this->peg_currPos;
+          $s6 = array();
+          $s7 = $this->peg_currPos;
+          $s8 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          $s9 = $this->peg_parseToken();
+          $this->peg_silentFails--;
+          if ($s9 === $this->peg_FAILED) {
+            $s8 = null;
+          } else {
+            $this->peg_currPos = $s8;
+            $s8 = $this->peg_FAILED;
+          }
+          if ($s8 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s9 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s9 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s9 !== $this->peg_FAILED) {
+              $s8 = array($s8, $s9);
+              $s7 = $s8;
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s7;
+            $s7 = $this->peg_FAILED;
+          }
+          while ($s7 !== $this->peg_FAILED) {
+            $s6[] = $s7;
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          }
+          if ($s6 !== $this->peg_FAILED) {
+            $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+          } else {
+            $s5 = $s6;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s3;
+            $s4 = $this->peg_f0($s1, $s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_currPos;
+          $s4 = $this->peg_parseToken();
+          if ($s4 !== $this->peg_FAILED) {
+            $s5 = $this->peg_currPos;
+            $s6 = array();
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+            while ($s7 !== $this->peg_FAILED) {
+              $s6[] = $s7;
+              $s7 = $this->peg_currPos;
+              $s8 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s9 = $this->peg_parseToken();
+              $this->peg_silentFails--;
+              if ($s9 === $this->peg_FAILED) {
+                $s8 = null;
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s9 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s9 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s9 !== $this->peg_FAILED) {
+                  $s8 = array($s8, $s9);
+                  $s7 = $s8;
+                } else {
+                  $this->peg_currPos = $s7;
+                  $s7 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+            } else {
+              $s5 = $s6;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s3;
+              $s4 = $this->peg_f0($s1, $s4, $s5);
+              $s3 = $s4;
+            } else {
+              $this->peg_currPos = $s3;
+              $s3 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_currPos;
+          $s4 = array();
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          while ($s5 !== $this->peg_FAILED) {
+            $s4[] = $s5;
+            if ($this->input_length > $this->peg_currPos) {
+              $s5 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s5 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f1($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
 
       return $s0;
     }
 
-    private function peg_parseWP_Block() {
+    private function peg_parseToken() {
 
-      $s0 = $this->peg_parseWP_Block_Void();
+      $s0 = $this->peg_parseTag_More();
       if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseWP_Block_Balanced();
+        $s0 = $this->peg_parseBlock_Void();
         if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseWP_Block_Html();
+          $s0 = $this->peg_parseBlock_Balanced();
         }
       }
 
       return $s0;
     }
 
-    private function peg_parseWP_Block_Void() {
+    private function peg_parseTag_More() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
         $s3 = $this->peg_parseWS();
-        if ($s3 !== $this->peg_FAILED) {
-          while ($s3 !== $this->peg_FAILED) {
-            $s2[] = $s3;
-            $s3 = $this->peg_parseWS();
-          }
-        } else {
-          $s2 = $this->peg_FAILED;
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseWS();
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
-            $this->peg_currPos += 3;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c3) {
+            $s3 = $this->peg_c3;
+            $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c4);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_currPos;
+            $s5 = array();
+            $s6 = $this->peg_parseWS();
+            if ($s6 !== $this->peg_FAILED) {
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
+              }
+            } else {
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $s6 = $this->peg_currPos;
+              $s7 = array();
+              $s8 = $this->peg_currPos;
+              $s9 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s10 = $this->peg_currPos;
+              $s11 = array();
+              $s12 = $this->peg_parseWS();
+              while ($s12 !== $this->peg_FAILED) {
+                $s11[] = $s12;
+                $s12 = $this->peg_parseWS();
+              }
+              if ($s11 !== $this->peg_FAILED) {
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
+                  $this->peg_currPos += 3;
+                } else {
+                  $s12 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
+                }
+                if ($s12 !== $this->peg_FAILED) {
+                  $s11 = array($s11, $s12);
+                  $s10 = $s11;
+                } else {
+                  $this->peg_currPos = $s10;
+                  $s10 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s10;
+                $s10 = $this->peg_FAILED;
+              }
+              $this->peg_silentFails--;
+              if ($s10 === $this->peg_FAILED) {
+                $s9 = null;
+              } else {
+                $this->peg_currPos = $s9;
+                $s9 = $this->peg_FAILED;
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s10 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s10 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s10 !== $this->peg_FAILED) {
+                  $s9 = array($s9, $s10);
+                  $s8 = $s9;
+                } else {
+                  $this->peg_currPos = $s8;
+                  $s8 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                while ($s8 !== $this->peg_FAILED) {
+                  $s7[] = $s8;
+                  $s8 = $this->peg_currPos;
+                  $s9 = $this->peg_currPos;
+                  $this->peg_silentFails++;
+                  $s10 = $this->peg_currPos;
+                  $s11 = array();
+                  $s12 = $this->peg_parseWS();
+                  while ($s12 !== $this->peg_FAILED) {
+                    $s11[] = $s12;
+                    $s12 = $this->peg_parseWS();
+                  }
+                  if ($s11 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                      $s12 = $this->peg_c5;
+                      $this->peg_currPos += 3;
+                    } else {
+                      $s12 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c6);
+                      }
+                    }
+                    if ($s12 !== $this->peg_FAILED) {
+                      $s11 = array($s11, $s12);
+                      $s10 = $s11;
+                    } else {
+                      $this->peg_currPos = $s10;
+                      $s10 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s10;
+                    $s10 = $this->peg_FAILED;
+                  }
+                  $this->peg_silentFails--;
+                  if ($s10 === $this->peg_FAILED) {
+                    $s9 = null;
+                  } else {
+                    $this->peg_currPos = $s9;
+                    $s9 = $this->peg_FAILED;
+                  }
+                  if ($s9 !== $this->peg_FAILED) {
+                    if ($this->input_length > $this->peg_currPos) {
+                      $s10 = $this->input_substr($this->peg_currPos, 1);
+                      $this->peg_currPos++;
+                    } else {
+                      $s10 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c0);
+                      }
+                    }
+                    if ($s10 !== $this->peg_FAILED) {
+                      $s9 = array($s9, $s10);
+                      $s8 = $s9;
+                    } else {
+                      $this->peg_currPos = $s8;
+                      $s8 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s8;
+                    $s8 = $this->peg_FAILED;
+                  }
+                }
+              } else {
+                $s7 = $this->peg_FAILED;
+              }
+              if ($s7 !== $this->peg_FAILED) {
+                $s6 = $this->input_substr($s6, $this->peg_currPos - $s6);
+              } else {
+                $s6 = $s7;
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $this->peg_reportedPos = $s4;
+                $s5 = $this->peg_f2($s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+            if ($s4 === $this->peg_FAILED) {
+              $s4 = null;
+            }
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
-              if ($s6 !== $this->peg_FAILED) {
-                while ($s6 !== $this->peg_FAILED) {
-                  $s5[] = $s6;
-                  $s6 = $this->peg_parseWS();
-                }
-              } else {
-                $s5 = $this->peg_FAILED;
+              while ($s6 !== $this->peg_FAILED) {
+                $s5[] = $s6;
+                $s6 = $this->peg_parseWS();
               }
               if ($s5 !== $this->peg_FAILED) {
-                $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
-                if ($s7 !== $this->peg_FAILED) {
-                  $s8 = array();
-                  $s9 = $this->peg_parseWS();
-                  if ($s9 !== $this->peg_FAILED) {
-                    while ($s9 !== $this->peg_FAILED) {
-                      $s8[] = $s9;
-                      $s9 = $this->peg_parseWS();
-                    }
-                  } else {
-                    $s8 = $this->peg_FAILED;
-                  }
-                  if ($s8 !== $this->peg_FAILED) {
-                    $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
-                    $s6 = $s7;
-                  } else {
-                    $this->peg_currPos = $s6;
-                    $s6 = $this->peg_FAILED;
-                  }
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
+                  $this->peg_currPos += 3;
                 } else {
-                  $this->peg_currPos = $s6;
                   $s6 = $this->peg_FAILED;
-                }
-                if ($s6 === $this->peg_FAILED) {
-                  $s6 = null;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c4) {
-                    $s7 = $this->peg_c4;
-                    $this->peg_currPos += 4;
-                  } else {
-                    $s7 = $this->peg_FAILED;
-                    if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c5);
+                  $s7 = $this->peg_currPos;
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  while ($s9 !== $this->peg_FAILED) {
+                    $s8[] = $s9;
+                    $s9 = $this->peg_parseWS();
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 15) === $this->peg_c7) {
+                      $s9 = $this->peg_c7;
+                      $this->peg_currPos += 15;
+                    } else {
+                      $s9 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c8);
+                      }
                     }
+                    if ($s9 !== $this->peg_FAILED) {
+                      $s8 = array($s8, $s9);
+                      $s7 = $s8;
+                    } else {
+                      $this->peg_currPos = $s7;
+                      $s7 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s7;
+                    $s7 = $this->peg_FAILED;
+                  }
+                  if ($s7 === $this->peg_FAILED) {
+                    $s7 = null;
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f1($s4, $s6);
+                    $s1 = $this->peg_f3($s4, $s7);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -447,79 +905,107 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Balanced() {
+    private function peg_parseBlock_Void() {
 
       $s0 = $this->peg_currPos;
-      $s1 = $this->peg_parseWP_Block_Start();
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
+        $this->peg_currPos += 4;
+      } else {
+        $s1 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c2);
+        }
+      }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
-        $s3 = $this->peg_currPos;
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_End();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s3;
-            $s4 = $this->peg_f2($s1, $s5);
-            $s3 = $s4;
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+        $s3 = $this->peg_parseWS();
+        if ($s3 !== $this->peg_FAILED) {
+          while ($s3 !== $this->peg_FAILED) {
+            $s2[] = $s3;
+            $s3 = $this->peg_parseWS();
           }
         } else {
-          $this->peg_currPos = $s3;
-          $s3 = $this->peg_FAILED;
-        }
-        while ($s3 !== $this->peg_FAILED) {
-          $s2[] = $s3;
-          $s3 = $this->peg_currPos;
-          $s4 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s5 = $this->peg_parseWP_Block_End();
-          $this->peg_silentFails--;
-          if ($s5 === $this->peg_FAILED) {
-            $s4 = null;
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
-          }
-          if ($s4 !== $this->peg_FAILED) {
-            $s5 = $this->peg_parseAny();
-            if ($s5 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s3;
-              $s4 = $this->peg_f2($s1, $s5);
-              $s3 = $s4;
-            } else {
-              $this->peg_currPos = $s3;
-              $s3 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
-          }
+          $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          $s3 = $this->peg_parseWP_Block_End();
-          if ($s3 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $this->peg_currPos;
-            $s4 = $this->peg_f3($s1, $s2, $s3);
-            if ($s4) {
-              $s4 = null;
-            } else {
-              $s4 = $this->peg_FAILED;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
+            $this->peg_currPos += 3;
+          } else {
+            $s3 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c10);
             }
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s0;
-              $s1 = $this->peg_f4($s1, $s2, $s3);
-              $s0 = $s1;
+              $s5 = array();
+              $s6 = $this->peg_parseWS();
+              if ($s6 !== $this->peg_FAILED) {
+                while ($s6 !== $this->peg_FAILED) {
+                  $s5[] = $s6;
+                  $s6 = $this->peg_parseWS();
+                }
+              } else {
+                $s5 = $this->peg_FAILED;
+              }
+              if ($s5 !== $this->peg_FAILED) {
+                $s6 = $this->peg_currPos;
+                $s7 = $this->peg_parseBlock_Attributes();
+                if ($s7 !== $this->peg_FAILED) {
+                  $s8 = array();
+                  $s9 = $this->peg_parseWS();
+                  if ($s9 !== $this->peg_FAILED) {
+                    while ($s9 !== $this->peg_FAILED) {
+                      $s8[] = $s9;
+                      $s9 = $this->peg_parseWS();
+                    }
+                  } else {
+                    $s8 = $this->peg_FAILED;
+                  }
+                  if ($s8 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s6;
+                    $s7 = $this->peg_f4($s4, $s7);
+                    $s6 = $s7;
+                  } else {
+                    $this->peg_currPos = $s6;
+                    $s6 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s6;
+                  $s6 = $this->peg_FAILED;
+                }
+                if ($s6 === $this->peg_FAILED) {
+                  $s6 = null;
+                }
+                if ($s6 !== $this->peg_FAILED) {
+                  if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c11) {
+                    $s7 = $this->peg_c11;
+                    $this->peg_currPos += 4;
+                  } else {
+                    $s7 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c12);
+                    }
+                  }
+                  if ($s7 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s0;
+                    $s1 = $this->peg_f5($s4, $s6);
+                    $s0 = $s1;
+                  } else {
+                    $this->peg_currPos = $s0;
+                    $s0 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s0;
+                  $s0 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s0;
+                $s0 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s0;
               $s0 = $this->peg_FAILED;
@@ -540,116 +1026,129 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Html() {
+    private function peg_parseBlock_Balanced() {
 
       $s0 = $this->peg_currPos;
-      $s1 = array();
-      $s2 = $this->peg_currPos;
-      $s3 = $this->peg_currPos;
-      $this->peg_silentFails++;
-      $s4 = $this->peg_parseWP_Block_Balanced();
-      $this->peg_silentFails--;
-      if ($s4 === $this->peg_FAILED) {
-        $s3 = null;
-      } else {
-        $this->peg_currPos = $s3;
-        $s3 = $this->peg_FAILED;
-      }
-      if ($s3 !== $this->peg_FAILED) {
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_Void();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s2;
-            $s3 = $this->peg_f5($s5);
-            $s2 = $s3;
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
-          }
-        } else {
-          $this->peg_currPos = $s2;
-          $s2 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s2;
-        $s2 = $this->peg_FAILED;
-      }
-      if ($s2 !== $this->peg_FAILED) {
-        while ($s2 !== $this->peg_FAILED) {
-          $s1[] = $s2;
-          $s2 = $this->peg_currPos;
+      $s1 = $this->peg_parseBlock_Start();
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_parseToken();
+        if ($s3 === $this->peg_FAILED) {
           $s3 = $this->peg_currPos;
+          $s4 = $this->peg_currPos;
+          $s5 = $this->peg_currPos;
           $this->peg_silentFails++;
-          $s4 = $this->peg_parseWP_Block_Balanced();
+          $s6 = $this->peg_parseBlock_End();
           $this->peg_silentFails--;
-          if ($s4 === $this->peg_FAILED) {
-            $s3 = null;
+          if ($s6 === $this->peg_FAILED) {
+            $s5 = null;
           } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
           }
-          if ($s3 !== $this->peg_FAILED) {
+          if ($s5 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s6 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s6 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = array($s5, $s6);
+              $s4 = $s5;
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseToken();
+          if ($s3 === $this->peg_FAILED) {
+            $s3 = $this->peg_currPos;
             $s4 = $this->peg_currPos;
+            $s5 = $this->peg_currPos;
             $this->peg_silentFails++;
-            $s5 = $this->peg_parseWP_Block_Void();
+            $s6 = $this->peg_parseBlock_End();
             $this->peg_silentFails--;
-            if ($s5 === $this->peg_FAILED) {
-              $s4 = null;
+            if ($s6 === $this->peg_FAILED) {
+              $s5 = null;
+            } else {
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s6 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s6 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $s5 = array($s5, $s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
             } else {
               $this->peg_currPos = $s4;
               $s4 = $this->peg_FAILED;
             }
             if ($s4 !== $this->peg_FAILED) {
-              $s5 = $this->peg_parseAny();
-              if ($s5 !== $this->peg_FAILED) {
-                $this->peg_reportedPos = $s2;
-                $s3 = $this->peg_f5($s5);
-                $s2 = $s3;
-              } else {
-                $this->peg_currPos = $s2;
-                $s2 = $this->peg_FAILED;
-              }
+              $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
             } else {
-              $this->peg_currPos = $s2;
-              $s2 = $this->peg_FAILED;
+              $s3 = $s4;
             }
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
           }
         }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_parseBlock_End();
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f6($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
       } else {
-        $s1 = $this->peg_FAILED;
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
-      if ($s1 !== $this->peg_FAILED) {
-        $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f6($s1);
-      }
-      $s0 = $s1;
 
       return $s0;
     }
 
-    private function peg_parseWP_Block_Start() {
+    private function peg_parseBlock_Start() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -664,17 +1163,17 @@ class php52_compat_Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c9) {
+            $s3 = $this->peg_c9;
             $this->peg_currPos += 3;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c10);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -688,7 +1187,7 @@ class php52_compat_Parser {
               }
               if ($s5 !== $this->peg_FAILED) {
                 $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
+                $s7 = $this->peg_parseBlock_Attributes();
                 if ($s7 !== $this->peg_FAILED) {
                   $s8 = array();
                   $s9 = $this->peg_parseWS();
@@ -702,7 +1201,7 @@ class php52_compat_Parser {
                   }
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f0($s4, $s7);
+                    $s7 = $this->peg_f4($s4, $s7);
                     $s6 = $s7;
                   } else {
                     $this->peg_currPos = $s6;
@@ -716,13 +1215,13 @@ class php52_compat_Parser {
                   $s6 = null;
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s7 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s7 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s7 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s7 !== $this->peg_FAILED) {
@@ -761,16 +1260,16 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_End() {
+    private function peg_parseBlock_End() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -785,17 +1284,17 @@ class php52_compat_Parser {
           $s2 = $this->peg_FAILED;
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c8) {
-            $s3 = $this->peg_c8;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c13) {
+            $s3 = $this->peg_c13;
             $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c9);
+                $this->peg_fail($this->peg_c14);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -808,13 +1307,13 @@ class php52_compat_Parser {
                 $s5 = $this->peg_FAILED;
               }
               if ($s5 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s6 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s6 !== $this->peg_FAILED) {
@@ -849,65 +1348,109 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Name() {
+    private function peg_parseBlock_Name() {
+
+      $s0 = $this->peg_parseNamespaced_Block_Name();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_parseCore_Block_Name();
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseNamespaced_Block_Name() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
-      $s2 = $this->peg_parseASCII_Letter();
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+          $s3 = $this->peg_c15;
+          $this->peg_currPos++;
+        } else {
+          $s3 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c16);
+          }
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s4 = $this->peg_parseBlock_Name_Part();
+          if ($s4 !== $this->peg_FAILED) {
+            $s2 = array($s2, $s3, $s4);
+            $s1 = $s2;
+          } else {
+            $this->peg_currPos = $s1;
+            $s1 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s1;
+          $s1 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s1;
+        $s1 = $this->peg_FAILED;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+      } else {
+        $s0 = $s1;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseCore_Block_Name() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = $this->peg_parseBlock_Name_Part();
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $s0;
+        $s1 = $this->peg_f9($s1);
+      }
+      $s0 = $s1;
+
+      return $s0;
+    }
+
+    private function peg_parseBlock_Name_Part() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      if (php52_compat_peg_regex_test($this->peg_c17, $this->input_substr($this->peg_currPos, 1))) {
+        $s2 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s2 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c18);
+        }
+      }
       if ($s2 !== $this->peg_FAILED) {
         $s3 = array();
-        $s4 = $this->peg_parseASCII_AlphaNumeric();
-        if ($s4 === $this->peg_FAILED) {
-          $s4 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-            $s5 = $this->peg_c10;
-            $this->peg_currPos++;
-          } else {
-            $s5 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c11);
-            }
-          }
-          if ($s5 !== $this->peg_FAILED) {
-            $s6 = $this->peg_parseASCII_AlphaNumeric();
-            if ($s6 !== $this->peg_FAILED) {
-              $s5 = array($s5, $s6);
-              $s4 = $s5;
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
+        if (php52_compat_peg_regex_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+          $s4 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s4 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c20);
           }
         }
         while ($s4 !== $this->peg_FAILED) {
           $s3[] = $s4;
-          $s4 = $this->peg_parseASCII_AlphaNumeric();
-          if ($s4 === $this->peg_FAILED) {
-            $s4 = $this->peg_currPos;
-            if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-              $s5 = $this->peg_c10;
-              $this->peg_currPos++;
-            } else {
-              $s5 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c11);
-              }
-            }
-            if ($s5 !== $this->peg_FAILED) {
-              $s6 = $this->peg_parseASCII_AlphaNumeric();
-              if ($s6 !== $this->peg_FAILED) {
-                $s5 = array($s5, $s6);
-                $s4 = $s5;
-              } else {
-                $this->peg_currPos = $s4;
-                $s4 = $this->peg_FAILED;
-              }
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
+          if (php52_compat_peg_regex_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+            $s4 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s4 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c20);
             }
           }
         }
@@ -931,18 +1474,18 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Attributes() {
+    private function peg_parseBlock_Attributes() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c12) {
-        $s3 = $this->peg_c12;
+      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c21) {
+        $s3 = $this->peg_c21;
         $this->peg_currPos++;
       } else {
         $s3 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c13);
+            $this->peg_fail($this->peg_c22);
         }
       }
       if ($s3 !== $this->peg_FAILED) {
@@ -951,13 +1494,13 @@ class php52_compat_Parser {
         $s6 = $this->peg_currPos;
         $this->peg_silentFails++;
         $s7 = $this->peg_currPos;
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-          $s8 = $this->peg_c14;
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+          $s8 = $this->peg_c23;
           $this->peg_currPos++;
         } else {
           $s8 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c15);
+              $this->peg_fail($this->peg_c24);
           }
         }
         if ($s8 !== $this->peg_FAILED) {
@@ -972,28 +1515,28 @@ class php52_compat_Parser {
             $s9 = $this->peg_FAILED;
           }
           if ($s9 !== $this->peg_FAILED) {
-            $s10 = $this->peg_c16;
+            $s10 = $this->peg_c25;
             if ($s10 !== $this->peg_FAILED) {
-              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                $s11 = $this->peg_c10;
+              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                $s11 = $this->peg_c15;
                 $this->peg_currPos++;
               } else {
                 $s11 = $this->peg_FAILED;
                 if ($this->peg_silentFails === 0) {
-                    $this->peg_fail($this->peg_c11);
+                    $this->peg_fail($this->peg_c16);
                 }
               }
               if ($s11 === $this->peg_FAILED) {
                 $s11 = null;
               }
               if ($s11 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                  $s12 = $this->peg_c6;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c7);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s12 !== $this->peg_FAILED) {
@@ -1033,7 +1576,7 @@ class php52_compat_Parser {
           } else {
             $s7 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c17);
+                $this->peg_fail($this->peg_c0);
             }
           }
           if ($s7 !== $this->peg_FAILED) {
@@ -1053,13 +1596,13 @@ class php52_compat_Parser {
           $s6 = $this->peg_currPos;
           $this->peg_silentFails++;
           $s7 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s8 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s8 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s8 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s8 !== $this->peg_FAILED) {
@@ -1074,28 +1617,28 @@ class php52_compat_Parser {
               $s9 = $this->peg_FAILED;
             }
             if ($s9 !== $this->peg_FAILED) {
-              $s10 = $this->peg_c16;
+              $s10 = $this->peg_c25;
               if ($s10 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c10) {
-                  $s11 = $this->peg_c10;
+                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                  $s11 = $this->peg_c15;
                   $this->peg_currPos++;
                 } else {
                   $s11 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c11);
+                      $this->peg_fail($this->peg_c16);
                   }
                 }
                 if ($s11 === $this->peg_FAILED) {
                   $s11 = null;
                 }
                 if ($s11 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c6) {
-                    $s12 = $this->peg_c6;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s12 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s12 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c7);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s12 !== $this->peg_FAILED) {
@@ -1135,7 +1678,7 @@ class php52_compat_Parser {
             } else {
               $s7 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c17);
+                  $this->peg_fail($this->peg_c0);
               }
             }
             if ($s7 !== $this->peg_FAILED) {
@@ -1151,13 +1694,13 @@ class php52_compat_Parser {
           }
         }
         if ($s4 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c14) {
-            $s5 = $this->peg_c14;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s5 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s5 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c15);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s5 !== $this->peg_FAILED) {
@@ -1182,87 +1725,14 @@ class php52_compat_Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f9($s1);
+        $s1 = $this->peg_f10($s1);
       }
       $s0 = $s1;
 
       return $s0;
     }
 
-    private function peg_parseASCII_AlphaNumeric() {
-
-      $s0 = $this->peg_parseASCII_Letter();
-      if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseASCII_Digit();
-        if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseSpecial_Chars();
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Letter() {
-
-      if (php52_compat_peg_regex_test($this->peg_c18, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c19);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Digit() {
-
-      if (php52_compat_peg_regex_test($this->peg_c20, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c21);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseSpecial_Chars() {
-
-      if (php52_compat_peg_regex_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c23);
-        }
-      }
-
-      return $s0;
-    }
-
     private function peg_parseWS() {
-
-      if (php52_compat_peg_regex_test($this->peg_c24, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c25);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseNewline() {
 
       if (php52_compat_peg_regex_test($this->peg_c26, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1277,7 +1747,7 @@ class php52_compat_Parser {
       return $s0;
     }
 
-    private function peg_parse_() {
+    private function peg_parseNewline() {
 
       if (php52_compat_peg_regex_test($this->peg_c28, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1286,6 +1756,21 @@ class php52_compat_Parser {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
             $this->peg_fail($this->peg_c29);
+        }
+      }
+
+      return $s0;
+    }
+
+    private function peg_parse_() {
+
+      if (php52_compat_peg_regex_test($this->peg_c30, $this->input_substr($this->peg_currPos, 1))) {
+        $s0 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s0 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c31);
         }
       }
 
@@ -1316,7 +1801,7 @@ class php52_compat_Parser {
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c17);
+            $this->peg_fail($this->peg_c0);
         }
       }
 
@@ -1340,39 +1825,41 @@ class php52_compat_Parser {
     mb_regex_encoding("UTF-8");
 
     $this->peg_FAILED = new stdClass;
-    $this->peg_c0 = "<!--";
-    $this->peg_c1 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
-    $this->peg_c2 = "wp:";
-    $this->peg_c3 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
-    $this->peg_c4 = "/-->";
-    $this->peg_c5 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
-    $this->peg_c6 = "-->";
-    $this->peg_c7 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
-    $this->peg_c8 = "/wp:";
-    $this->peg_c9 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
-    $this->peg_c10 = "/";
-    $this->peg_c11 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
-    $this->peg_c12 = "{";
-    $this->peg_c13 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
-    $this->peg_c14 = "}";
-    $this->peg_c15 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
-    $this->peg_c16 = "";
-    $this->peg_c17 = array("type" => "any", "description" => "any character" );
-    $this->peg_c18 = "/^[a-zA-Z]/";
-    $this->peg_c19 = array( "type" => "class", "value" => "[a-zA-Z]", "description" => "[a-zA-Z]" );
-    $this->peg_c20 = "/^[0-9]/";
-    $this->peg_c21 = array( "type" => "class", "value" => "[0-9]", "description" => "[0-9]" );
-    $this->peg_c22 = "/^[-_]/";
-    $this->peg_c23 = array( "type" => "class", "value" => "[-_]", "description" => "[-_]" );
-    $this->peg_c24 = "/^[ \\t\\r\\n]/";
-    $this->peg_c25 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
-    $this->peg_c26 = "/^[\\r\\n]/";
-    $this->peg_c27 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
-    $this->peg_c28 = "/^[ \\t]/";
-    $this->peg_c29 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
+    $this->peg_c0 = array("type" => "any", "description" => "any character" );
+    $this->peg_c1 = "<!--";
+    $this->peg_c2 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
+    $this->peg_c3 = "more";
+    $this->peg_c4 = array( "type" => "literal", "value" => "more", "description" => "\"more\"" );
+    $this->peg_c5 = "-->";
+    $this->peg_c6 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
+    $this->peg_c7 = "<!--noteaser-->";
+    $this->peg_c8 = array( "type" => "literal", "value" => "<!--noteaser-->", "description" => "\"<!--noteaser-->\"" );
+    $this->peg_c9 = "wp:";
+    $this->peg_c10 = array( "type" => "literal", "value" => "wp:", "description" => "\"wp:\"" );
+    $this->peg_c11 = "/-->";
+    $this->peg_c12 = array( "type" => "literal", "value" => "/-->", "description" => "\"/-->\"" );
+    $this->peg_c13 = "/wp:";
+    $this->peg_c14 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
+    $this->peg_c15 = "/";
+    $this->peg_c16 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
+    $this->peg_c17 = "/^[a-z]/";
+    $this->peg_c18 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
+    $this->peg_c19 = "/^[a-z0-9_-]/";
+    $this->peg_c20 = array( "type" => "class", "value" => "[a-z0-9_-]", "description" => "[a-z0-9_-]" );
+    $this->peg_c21 = "{";
+    $this->peg_c22 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
+    $this->peg_c23 = "}";
+    $this->peg_c24 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
+    $this->peg_c25 = "";
+    $this->peg_c26 = "/^[ \\t\\r\\n]/";
+    $this->peg_c27 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
+    $this->peg_c28 = "/^[\\r\\n]/";
+    $this->peg_c29 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
+    $this->peg_c30 = "/^[ \\t]/";
+    $this->peg_c31 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
 
-    $peg_startRuleFunctions = array( 'Document' => array($this, "peg_parseDocument") );
-    $peg_startRuleFunction  = array($this, "peg_parseDocument");
+    $peg_startRuleFunctions = array( 'Block_List' => array($this, "peg_parseBlock_List") );
+    $peg_startRuleFunction  = array($this, "peg_parseBlock_List");
     if (isset($options["startRule"])) {
       if (!(isset($peg_startRuleFunctions[$options["startRule"]]))) {
         throw new Exception("Can't start parsing from rule \"" + $options["startRule"] + "\".");
@@ -1385,6 +1872,49 @@ class php52_compat_Parser {
 
     // The `maybeJSON` function is not needed in PHP because its return semantics
     // are the same as `json_decode`
+
+    // array arguments are backwards because of PHP
+    if ( ! function_exists( 'peg_array_partition' ) ) {
+        function peg_array_partition( $array, $predicate ) {
+            $truthy = array();
+            $falsey = array();
+
+            foreach ( $array as $item ) {
+                call_user_func( $predicate, $item )
+                    ? $truthy[] = $item
+                    : $falsey[] = $item;
+            }
+
+            return array( $truthy, $falsey );
+        }
+    }
+
+    if ( ! function_exists( 'peg_join_blocks' ) ) {
+        function peg_join_blocks( $pre, $tokens, $post ) {
+            $blocks = array();
+
+            if ( ! empty( $pre ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+            }
+
+            foreach ( $tokens as $token ) {
+                list( $token, $html ) = $token;
+
+                $blocks[] = $token;
+
+                if ( ! empty( $html ) ) {
+                    $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+                }
+            }
+
+            if ( ! empty( $post ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+            }
+
+            return $blocks;
+        }
+    }
+
 
     /* END initializer code */
 

--- a/test/fixtures/wp-gutenberg-post/example-post.json
+++ b/test/fixtures/wp-gutenberg-post/example-post.json
@@ -4,28 +4,34 @@
         "attrs": {
             "align": "right"
         },
-        "rawContent": "\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n",
+        "outerHTML": "<!-- wp:text {\"align\":\"right\"} -->\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n<!-- /wp:text -->"
     },
     {
         "attrs": [],
-        "rawContent": "\n\n"
+        "innerHTML": "\n\n"
     },
     {
         "blockName": "core/separator",
         "attrs": null,
-        "rawContent": "\n<hr class=\"wp-block-separator\" />\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<hr class=\"wp-block-separator\">\n",
+        "outerHTML": "<!-- wp:separator -->\n<hr class=\"wp-block-separator\">\n<!-- /wp:separator -->"
     },
     {
         "attrs": [],
-        "rawContent": "\n\n"
+        "innerHTML": "\n\n"
     },
     {
         "blockName": "core/freeform",
         "attrs": null,
-        "rawContent": "\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n"
+        "innerBlocks": [],
+        "innerHTML": "\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n",
+        "outerHTML": "<!-- wp:freeform -->\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n<!-- /wp:freeform -->"
     },
     {
         "attrs": [],
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/test/fixtures/wp-gutenberg-post/example-post.txt
+++ b/test/fixtures/wp-gutenberg-post/example-post.txt
@@ -1,14 +1,14 @@
-<!-- wp:core/text {"align":"right"} -->
+<!-- wp:text {"align":"right"} -->
 <p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
-<!-- /wp:core/text -->
+<!-- /wp:text -->
 
-<!-- wp:core/separator -->
-<hr class="wp-block-separator" />
-<!-- /wp:core/separator -->
+<!-- wp:separator -->
+<hr class="wp-block-separator">
+<!-- /wp:separator -->
 
-<!-- wp:core/freeform -->
+<!-- wp:freeform -->
 Testing freeform block with some
 <div class="wp-some-class">
 	HTML <span style="color: red;">content</span>
 </div>
-<!-- /wp:core/freeform -->
+<!-- /wp:freeform -->


### PR DESCRIPTION
Related: https://github.com/Nordth/php-pegjs/commit/88960c47e4a5c266d28379fdb1d8a65c59253123

The current implementation of `$this->text()` does not work correctly, since it attempts to apply `substr` on an array.

>Warning: substr() expects parameter 1 to be string, array given in /srv/www/editor/htdocs/wp-content/plugins/gutenberg/lib/parser.php on line 105

The proposed changes here use `$this->input_str` instead to iterate the `$this->input` array. Further, it applies the fix from https://github.com/Nordth/php-pegjs/commit/88960c47e4a5c266d28379fdb1d8a65c59253123 which otherwise does not correctly identify the termination of a token.

Fixtures have been updated to use the current Gutenberg post grammar as of https://github.com/WordPress/gutenberg/pull/2743 (__Edit:__ Correction: it includes a new `outerHTML` property which will be proposed soon, leveraging `$this->text()`). Fixtures for `wp-gutenberg-post-with-errors` have been removed since the new grammar is capable of identifying non-block content.